### PR TITLE
crash due to use_citusdb_select_logic on postgres is fixed (#10)

### DIFF
--- a/pg_shard.c
+++ b/pg_shard.c
@@ -267,7 +267,7 @@ PgShardPlanner(Query *query, int cursorOptions, ParamListInfo boundParams)
 	}
 	else if (plannerType == PLANNER_TYPE_CITUSDB)
 	{
-		if(PreviousPlannerHook == NULL)
+		if (PreviousPlannerHook == NULL)
 		{
 			ereport(ERROR, (errmsg("could not plan SELECT query"),
 							errdetail("Configured to use CitusDB's SELECT "


### PR DESCRIPTION
issue #10 is fixed.

Review tasks:
- [x] Ensure SQL keywords are capitalized in error text
- [x] Quote identifiers, variable names, file names, parameter values etc. using double quotes
- [x] Get rid of the word "execute" in the message (we're not to execution yet)
- [x] Add an `errdetail` to explain why the query could not be planned
- [x] Clarify the hint text
