### PR TITLE
Improve unsupported feature identification - Subqueries, CTEs and Functions

### DIFF
--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -92,7 +92,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (DELETE FROM limit_orders RETURNING *)
 INSERT INTO limit_orders DEFAULT VALUES;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+DETAIL:  Common table entries are currently unsupported.
 -- test simple delete
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
@@ -140,7 +140,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 DELETE FROM limit_orders;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+DETAIL:  Common table entries are currently unsupported.
 -- cursors are not supported
 DELETE FROM limit_orders WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query
@@ -186,7 +186,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 UPDATE limit_orders SET symbol = 'GM';
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+DETAIL:  Common table entries are currently unsupported.
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query

--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -82,7 +82,8 @@ INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);
 ERROR:  multi-row INSERTs to distributed tables are not supported
 -- insert from queries are unsupported
 INSERT INTO limit_orders SELECT * FROM limit_orders;
-ERROR:  unsupported range table type: 1
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries are currently unsupported.
 -- queries with a returning clause are unsupported
 INSERT INTO limit_orders VALUES (7285, 'AMZN', 3278, '2016-01-05 02:07:36', 'sell', 0.00)
 						 RETURNING *;
@@ -91,7 +92,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (DELETE FROM limit_orders RETURNING *)
 INSERT INTO limit_orders DEFAULT VALUES;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
+DETAIL:  Joins are currently unsupported.
 -- test simple delete
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
@@ -131,7 +132,7 @@ DELETE FROM limit_orders USING bidders WHERE limit_orders.id = 246 AND
 											 limit_orders.bidder_id = bidders.id AND
 											 bidders.name = 'Bernie Madoff';
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
+DETAIL:  Joins are currently unsupported.
 -- queries with a returning clause are unsupported
 DELETE FROM limit_orders WHERE id = 246 RETURNING *;
 ERROR:  cannot plan sharded modification that uses a RETURNING clause
@@ -139,7 +140,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 DELETE FROM limit_orders;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
+DETAIL:  Joins are currently unsupported.
 -- cursors are not supported
 DELETE FROM limit_orders WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query
@@ -177,7 +178,7 @@ UPDATE limit_orders SET limit_price = 0.00 FROM bidders
 						  limit_orders.bidder_id = bidders.id AND
 						  bidders.name = 'Bernie Madoff';
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
+DETAIL:  Joins are currently unsupported.
 -- queries with a returning clause are unsupported
 UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
 ERROR:  cannot plan sharded modification that uses a RETURNING clause
@@ -185,7 +186,7 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 UPDATE limit_orders SET symbol = 'GM';
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
+DETAIL:  Joins are currently unsupported.
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query

--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -82,8 +82,8 @@ INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);
 ERROR:  multi-row INSERTs to distributed tables are not supported
 -- insert from queries are unsupported
 INSERT INTO limit_orders SELECT * FROM limit_orders;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Subqueries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Subqueries are not supported in distributed queries.
 -- queries with a returning clause are unsupported
 INSERT INTO limit_orders VALUES (7285, 'AMZN', 3278, '2016-01-05 02:07:36', 'sell', 0.00)
 						 RETURNING *;
@@ -91,8 +91,8 @@ ERROR:  cannot plan sharded modification that uses a RETURNING clause
 -- queries containing a CTE are unsupported
 WITH deleted_orders AS (DELETE FROM limit_orders RETURNING *)
 INSERT INTO limit_orders DEFAULT VALUES;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Common table entries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Common table expressions are not supported in distributed queries.
 -- test simple delete
 INSERT INTO limit_orders VALUES (246, 'TSLA', 162, '2007-07-02 16:32:15', 'sell', 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 246;
@@ -131,16 +131,16 @@ CREATE TABLE bidders ( name text, id bigint );
 DELETE FROM limit_orders USING bidders WHERE limit_orders.id = 246 AND
 											 limit_orders.bidder_id = bidders.id AND
 											 bidders.name = 'Bernie Madoff';
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Joins are not supported in distributed queries.
 -- queries with a returning clause are unsupported
 DELETE FROM limit_orders WHERE id = 246 RETURNING *;
 ERROR:  cannot plan sharded modification that uses a RETURNING clause
 -- queries containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 DELETE FROM limit_orders;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Common table entries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Common table expressions are not supported in distributed queries.
 -- cursors are not supported
 DELETE FROM limit_orders WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query
@@ -177,16 +177,16 @@ UPDATE limit_orders SET limit_price = 0.00 FROM bidders
 					WHERE limit_orders.id = 246 AND
 						  limit_orders.bidder_id = bidders.id AND
 						  bidders.name = 'Bernie Madoff';
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Joins are not supported in distributed queries.
 -- queries with a returning clause are unsupported
 UPDATE limit_orders SET symbol = 'GM' WHERE id = 246 RETURNING *;
 ERROR:  cannot plan sharded modification that uses a RETURNING clause
 -- queries containing a CTE are unsupported
 WITH deleted_orders AS (INSERT INTO limit_orders DEFAULT VALUES RETURNING *)
 UPDATE limit_orders SET symbol = 'GM';
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Common table entries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Common table expressions are not supported in distributed queries.
 -- cursors are not supported
 UPDATE limit_orders SET symbol = 'GM' WHERE CURRENT OF cursor_name;
 ERROR:  cannot modify multiple shards during a single query

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -162,6 +162,10 @@ WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Common table entries are currently unsupported.
+--  queries which involve functions in FROM clause are unsupported.
+select * from  articles, position('om' in 'Thomas');
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Functions are currently unsupported in FROM clause.
 -- subqueries are not supported in WHERE clause
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
 ERROR:  cannot perform distributed planning on this query

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -162,18 +162,18 @@ SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIK
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Subqueries are currently unsupported.
 -- subqueries are not supported in FROM clause
-SELECT articles.id,test.word_count from articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
+SELECT articles.id,test.word_count FROM articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Subqueries are currently unsupported.
 -- subqueries are not supported in SELECT clause
 SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Subqueries are currently unsupported.
--- joins are unsupported in WHERE clause
+-- joins are not supported in WHERE clause
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Joins are currently unsupported.
--- joins are unsupported in FROM clause
+-- joins are not supported in FROM clause
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Joins are currently unsupported.

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -161,7 +161,7 @@ CREATE TABLE authors ( name text, id bigint );
 WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+DETAIL:  Common table entries are currently unsupported.
 -- subqueries are not supported in WHERE clause
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
 ERROR:  cannot perform distributed planning on this query

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -174,7 +174,7 @@ SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.au
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Joins are currently unsupported.
 -- joins are unsupported in FROM clause
-SELECT * FROM  (articles INNER JOIN authors ON articles.id=authors.id);
+SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 ERROR:  cannot perform distributed planning on this query
 DETAIL:  Joins are currently unsupported.
 -- test cross-shard queries

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -149,20 +149,34 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles
 -- UNION/INTERSECT queries are unsupported
 SELECT * FROM articles WHERE author_id = 10 UNION
 SELECT * FROM articles WHERE author_id = 1; 
-ERROR:  unsupported range table type: 1
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries are currently unsupported.
 -- queries using CTEs are unsupported
 CREATE TABLE authors ( name text, id bigint );
 WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
--- joins are unsupported
+DETAIL:  Joins are currently unsupported.
+-- subqueries are not supported in WHERE clause
+SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries are currently unsupported.
+-- subqueries are not supported in FROM clause
+SELECT articles.id,test.word_count from articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries are currently unsupported.
+-- subqueries are not supported in SELECT clause
+SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Subqueries are currently unsupported.
+-- joins are unsupported in WHERE clause
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported
--- subqueries are not supported
-SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
-ERROR:  unsupported range table type: 1
+DETAIL:  Joins are currently unsupported.
+-- joins are unsupported in FROM clause
+SELECT * FROM  (articles INNER JOIN authors ON articles.id=authors.id);
+ERROR:  cannot perform distributed planning on this query
+DETAIL:  Joins are currently unsupported.
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
  count 

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -154,38 +154,38 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles
 -- UNION/INTERSECT queries are unsupported
 SELECT * FROM articles WHERE author_id = 10 UNION
 SELECT * FROM articles WHERE author_id = 1; 
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Subqueries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Subqueries are not supported in distributed queries.
 -- queries using CTEs are unsupported
 CREATE TABLE authors ( name text, id bigint );
 WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Common table entries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Common table expressions are not supported in distributed queries.
 --  queries which involve functions in FROM clause are unsupported.
-select * from  articles, position('om' in 'Thomas');
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Functions are currently unsupported in FROM clause.
+SELECT * FROM articles, position('om' in 'Thomas');
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Functions must not appear in the FROM clause of a distributed query.
 -- subqueries are not supported in WHERE clause
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Subqueries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Subqueries are not supported in distributed queries.
 -- subqueries are not supported in FROM clause
 SELECT articles.id,test.word_count FROM articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Subqueries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Subqueries are not supported in distributed queries.
 -- subqueries are not supported in SELECT clause
 SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Subqueries are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Subqueries are not supported in distributed queries.
 -- joins are not supported in WHERE clause
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Joins are not supported in distributed queries.
 -- joins are not supported in FROM clause
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
-ERROR:  cannot perform distributed planning on this query
-DETAIL:  Joins are currently unsupported.
+ERROR:  cannot perform distributed planning for the given query
+DETAIL:  Joins are not supported in distributed queries.
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
  count 

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -385,16 +385,20 @@ ErrorIfQueryNotSupported(Query *queryTree)
 	if (queryTree->hasSubLinks == true)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot perform distributed planning on this query"),
-						errdetail("Subqueries are currently unsupported.")));
+						errmsg("cannot perform distributed planning for the given"
+							   " query"),
+						errdetail("Subqueries are not supported in distributed"
+								  " queries.")));
 	}
 
 	/* reject queries which include CommonTableExpr */
 	if (queryTree->cteList != NIL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot perform distributed planning on this query"),
-						errdetail("Common table entries are currently unsupported.")));
+						errmsg("cannot perform distributed planning for the given"
+							   " query"),
+						errdetail("Common table expressions are not supported in"
+								  " distributed queries.")));
 	}
 
 	/* extract range table entries */
@@ -423,16 +427,18 @@ ErrorIfQueryNotSupported(Query *queryTree)
 			char *rangeTableEntryErrorDetail = NULL;
 			if (rangeTableEntry->rtekind == RTE_SUBQUERY)
 			{
-				rangeTableEntryErrorDetail = "Subqueries are currently unsupported.";
+				rangeTableEntryErrorDetail = "Subqueries are not supported in"
+											 " distributed queries.";
 			}
 			else if (rangeTableEntry->rtekind == RTE_JOIN)
 			{
-				rangeTableEntryErrorDetail = "Joins are currently unsupported.";
+				rangeTableEntryErrorDetail = "Joins are not supported in distributed"
+											 " queries.";
 			}
 			else if (rangeTableEntry->rtekind == RTE_FUNCTION)
 			{
-				rangeTableEntryErrorDetail = "Functions are currently unsupported"
-											 " in FROM clause.";
+				rangeTableEntryErrorDetail = "Functions must not appear in the FROM"
+											 " clause of a distributed query.";
 			}
 			else
 			{
@@ -440,7 +446,8 @@ ErrorIfQueryNotSupported(Query *queryTree)
 			}
 
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("cannot perform distributed planning on this query"),
+							errmsg("cannot perform distributed planning for the given"
+								   " query"),
 							errdetail("%s", rangeTableEntryErrorDetail)));
 		}
 	}
@@ -449,8 +456,9 @@ ErrorIfQueryNotSupported(Query *queryTree)
 	if (queryTableCount != 1)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot perform distributed planning on this query"),
-						errdetail("Joins are currently unsupported.")));
+						errmsg("cannot perform distributed planning for the given"
+							   " query"),
+						errdetail("Joins are not supported in distributed queries.")));
 	}
 
 	/* reject queries which involve multi-row inserts */

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -376,7 +376,7 @@ ErrorIfQueryNotSupported(Query *queryTree)
 	}
 
 	/*
-	 * Reject subqueries which are not in FROM clause.
+	 * Reject subqueries which are in SELECT or WHERE clause.
 	 * Queries which include subqueries in FROM clauses are rejected below.
 	 */
 	if (queryTree->hasSubLinks == true)

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -107,11 +107,20 @@ CREATE TABLE authors ( name text, id bigint );
 WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 
--- joins are unsupported
+-- subqueries are not supported in WHERE clause
+SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
+
+-- subqueries are not supported in FROM clause
+SELECT articles.id,test.word_count from articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
+
+-- subqueries are not supported in SELECT clause
+SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;
+
+-- joins are unsupported in WHERE clause
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 
--- subqueries are not supported
-SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
+-- joins are unsupported in FROM clause
+SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -116,11 +116,14 @@ SELECT articles.id,test.word_count FROM articles, (SELECT id, word_count FROM ar
 -- subqueries are not supported in SELECT clause
 SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;
 
--- joins are unsupported in WHERE clause
+-- joins are not supported in WHERE clause
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 
--- joins are unsupported in FROM clause
+-- joins are not supported in FROM clause
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
+
+
+
 
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -111,7 +111,7 @@ WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 
 --  queries which involve functions in FROM clause are unsupported.
-select * from  articles, position('om' in 'Thomas');
+SELECT * FROM articles, position('om' in 'Thomas');
 
 -- subqueries are not supported in WHERE clause
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
@@ -127,9 +127,6 @@ SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.au
 
 -- joins are not supported in FROM clause
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
-
-
-
 
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -110,6 +110,9 @@ CREATE TABLE authors ( name text, id bigint );
 WITH long_names AS ( SELECT id FROM authors WHERE char_length(name) > 15 )
 SELECT title FROM articles;
 
+--  queries which involve functions in FROM clause are unsupported.
+select * from  articles, position('om' in 'Thomas');
+
 -- subqueries are not supported in WHERE clause
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
 

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -111,7 +111,7 @@ SELECT title FROM articles;
 SELECT * FROM articles WHERE author_id IN (SELECT id FROM authors WHERE name LIKE '%a');
 
 -- subqueries are not supported in FROM clause
-SELECT articles.id,test.word_count from articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
+SELECT articles.id,test.word_count FROM articles, (SELECT id, word_count FROM articles) AS test where test.id = articles.id;
 
 -- subqueries are not supported in SELECT clause
 SELECT  a.title AS  name,(SELECT a2.id FROM authors a2 WHERE a.id = a2.id  LIMIT 1) AS special_price FROM articles a;


### PR DESCRIPTION
Hey @jasonmp85 ,

* For subqueries we need to make two checks, which we discussed earlier:
    1. One for queryTree->hasSubLinks == true
    2. One for rangeTableEntry->rtekind == RTE_SUBQUERY

* For the common table expressions, I added a new check. In the query struct, there is a queryTree->cteList field. Wherever a CTE exits in a query (SELECT,FROM or WHERE), the field is updated.

* Since we do not support CTEs at all, it is OK to check that variable. Also, it becomes unnecessary to check it in range table entries iteration.

* I think we also need to disccuss functions. For the functions which appears in SELECT or WHERE clause, we can plan the query and get correct results (as far as I observed).

* However, for the functions which appears in FROM clause, we fail to plan and execute the query. Thus, I explictly added a check for rangeTableEntry->rtekind == RTE_FUNCTION. Could I be missing anything on that?

* I added unit tests for each case. Also, tests for common table entries were erroring out wrong, reporting that "Joins are unsupported". I also updated that error report too.

fixes #14
fixes #46

Review tasks:

  - [x] Update messages and details with provided text
  - [x] Change tests to use uppercase keywords
  - [x] Remove extraneous space in tests
