### PR TITLE
Fix multi-shard SELECT problem with HAVING clauses

### DIFF
--- a/expected/queries.out
+++ b/expected/queries.out
@@ -193,6 +193,7 @@ SELECT COUNT(*) FROM articles;
     50
 (1 row)
 
+-- try query with more SQL features
 SELECT author_id, sum(word_count) AS corpus_size FROM articles
 	GROUP BY author_id
 	HAVING sum(word_count) > 25000
@@ -220,6 +221,20 @@ LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10036 WHERE
 
 SET client_min_messages = DEFAULT;
 SET pg_shard.log_distributed_statements = DEFAULT;
+-- use HAVING without its variable in target list
+SELECT author_id FROM articles
+	GROUP BY author_id
+	HAVING sum(word_count) > 50000
+	ORDER BY author_id;
+ author_id 
+-----------
+         2
+         4
+         6
+         8
+        10
+(5 rows)
+
 -- verify temp tables used by cross-shard queries do not persist
 SELECT COUNT(*) FROM pg_class WHERE relname LIKE 'pg_shard_temp_table%' AND
 									relkind = 'r';

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -709,6 +709,7 @@ RowAndColumnFilterQuery(Query *query, List *remoteRestrictList, List *localRestr
 	List *rangeTableList = NIL;
 	List *whereColumnList = NIL;
 	List *projectColumnList = NIL;
+	List *havingClauseColumnList = NIL;
 	List *requiredColumnList = NIL;
 	ListCell *columnCell = NULL;
 	List *uniqueColumnList = NIL;
@@ -733,9 +734,14 @@ RowAndColumnFilterQuery(Query *query, List *remoteRestrictList, List *localRestr
 	projectColumnList = pull_var_clause((Node *) query->targetList, aggregateBehavior,
 										placeHolderBehavior);
 
+	/* finally, need those used in any HAVING quals */
+	havingClauseColumnList = pull_var_clause(query->havingQual, aggregateBehavior,
+											 placeHolderBehavior);
+
 	/* put them together to get list of required columns for query */
 	requiredColumnList = list_concat(requiredColumnList, whereColumnList);
 	requiredColumnList = list_concat(requiredColumnList, projectColumnList);
+	requiredColumnList = list_concat(requiredColumnList, havingClauseColumnList);
 
 	/* ensure there are no duplicates in the list  */
 	foreach(columnCell, requiredColumnList)

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -131,6 +131,7 @@ SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
 
+-- try query with more SQL features
 SELECT author_id, sum(word_count) AS corpus_size FROM articles
 	GROUP BY author_id
 	HAVING sum(word_count) > 25000
@@ -145,6 +146,12 @@ SELECT count(*) FROM articles WHERE word_count > 10000;
 
 SET client_min_messages = DEFAULT;
 SET pg_shard.log_distributed_statements = DEFAULT;
+
+-- use HAVING without its variable in target list
+SELECT author_id FROM articles
+	GROUP BY author_id
+	HAVING sum(word_count) > 50000
+	ORDER BY author_id;
 
 -- verify temp tables used by cross-shard queries do not persist
 SELECT COUNT(*) FROM pg_class WHERE relname LIKE 'pg_shard_temp_table%' AND


### PR DESCRIPTION
Because `Var`s from `HAVING` clauses weren't being included in the remote query's target list, they would be `NULL` if they did not appear in the target list or a `GROUP`/`ORDER` clause. This change includes them in the remote target list so they'll be available for local evaluation of the `HAVING` clause.

fixes #53