### PR TITLE
pg_shard performance improvement

### DIFF
--- a/prune_shard_list.c
+++ b/prune_shard_list.c
@@ -275,10 +275,9 @@ LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
 	/* if not found in the cache, call GetOperatorByType and put the result in cache */
 	if (matchingCacheEntry == NULL)
 	{
-		Oid operatorId;
-		MemoryContext oldContext;
+		MemoryContext oldContext = NULL;
+		Oid operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
 
-		operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
 		if (operatorId == InvalidOid)
 		{
 			/* if operatorId is invalid, return and do not cache its value */

--- a/prune_shard_list.c
+++ b/prune_shard_list.c
@@ -39,10 +39,20 @@
 #include "utils/errcodes.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
+#include "utils/memutils.h"
+
+
+/*
+ * OperatorTypeCache is used for caching base operator types for given typeId,
+ * accessMethodId and strategyNumber. It is initialized to empty list as
+ * there are no items in the cache.
+ */
+static List *OperatorTypeCache = NIL;
 
 
 /* local function forward declarations */
 static Oid GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
+static Oid LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
 static bool SimpleOpExpression(Expr *clause);
 static Node * HashableClauseMutator(Node *originalNode, Var *partitionColumn);
 static bool OpExpressionContainsColumn(OpExpr *operatorExpression, Var *partitionColumn);
@@ -218,7 +228,7 @@ MakeOpExpression(Var *variable, int16 strategyNumber)
 	OpExpr *expression = NULL;
 
 	/* Load the operator from system catalogs */
-	operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
+	operatorId = LookupOperatorByType(typeId, accessMethodId, strategyNumber);
 
 	constantValue = makeNullConst(typeId, typeModId, collationId);
 
@@ -235,6 +245,51 @@ MakeOpExpression(Var *variable, int16 strategyNumber)
 	expression->opresulttype = get_func_rettype(expression->opfuncid);
 
 	return expression;
+}
+
+
+/*
+ * LookupOperatorByType is a wrapper around GetOperatorByType that uses a cache
+ * to avoid multiple lookups of operators by their types.
+ */
+static Oid
+LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
+{
+	OperatorTypeCacheEntry *matchingCacheEntry = NULL;
+	ListCell *cacheEntryCell = NULL;
+
+	/* search the cache */
+	foreach(cacheEntryCell, OperatorTypeCache)
+	{
+		OperatorTypeCacheEntry *cacheEntry = lfirst(cacheEntryCell);
+
+		if (cacheEntry->typeId == typeId && cacheEntry->accessMethodId == accessMethodId
+			&& cacheEntry->strategyNumber == strategyNumber)
+		{
+			matchingCacheEntry = cacheEntry;
+			break;
+		}
+	}
+
+	/* if not found in the cache, call GetOperatorByType and put the result in cache */
+	if (matchingCacheEntry == NULL)
+	{
+		Oid operatorId = GetOperatorByType(typeId, accessMethodId, strategyNumber);
+		MemoryContext oldContext = MemoryContextSwitchTo(CacheMemoryContext);
+
+		matchingCacheEntry = palloc0(sizeof(OperatorTypeCacheEntry));
+		matchingCacheEntry->typeId = typeId;
+		matchingCacheEntry->accessMethodId = accessMethodId;
+		matchingCacheEntry->strategyNumber = strategyNumber;
+
+		matchingCacheEntry->operatorId = operatorId;
+
+		OperatorTypeCache = lappend(OperatorTypeCache, matchingCacheEntry);
+
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	return matchingCacheEntry->operatorId;
 }
 
 

--- a/prune_shard_list.h
+++ b/prune_shard_list.h
@@ -31,6 +31,21 @@
 #define RESERVED_HASHED_COLUMN_ID MaxAttrNumber
 
 
+/*
+ * OperatorTypeCacheEntry contains the information for a cache entry in
+ * operator type cache.
+ */
+typedef struct OperatorTypeCacheEntry
+{
+	/* cache key consists of typeId, accessMethodId and strategyNumber */
+	Oid typeId;
+	Oid accessMethodId;
+	int16 strategyNumber;
+
+	Oid operatorId;
+} OperatorTypeCacheEntry;
+
+
 /* function declarations for shard pruning */
 extern List * PruneShardList(Oid relationId, List *whereClauseList,
 							 List *shardIntervalList);

--- a/prune_shard_list.h
+++ b/prune_shard_list.h
@@ -31,19 +31,15 @@
 #define RESERVED_HASHED_COLUMN_ID MaxAttrNumber
 
 
-/*
- * OperatorTypeCacheEntry contains the information for a cache entry in
- * operator type cache.
- */
-typedef struct OperatorTypeCacheEntry
+ /* OperatorIdCacheEntry contains information for each element in OperatorIdCache */
+typedef struct OperatorIdCacheEntry
 {
 	/* cache key consists of typeId, accessMethodId and strategyNumber */
 	Oid typeId;
 	Oid accessMethodId;
 	int16 strategyNumber;
-
 	Oid operatorId;
-} OperatorTypeCacheEntry;
+} OperatorIdCacheEntry;
 
 
 /* function declarations for shard pruning */


### PR DESCRIPTION
This branch implements a cache in front of  *GetOperatorByType* function, so that it prevents unnecessary calls to *GetDefaultOpClass* function.

With this implementation, we get the same performance improvement that we observed with @ozgune. I may send the details of the results via an email.

fixes #50

Review tasks:
  - [x] Replace appearances of `OperatorType` with `OperatorId` (also check comments)
  - [x] Short-circuit without caching if `GetOperatorByType` returns `InvalidOid`
  - [x] Clean up the `if` statement with the three boolean expressions
  - [x] Ensure function declaration order matches definition order
