### PR TITLE
Handle zero-shard SELECT queries

### DIFF
--- a/expected/queries.out
+++ b/expected/queries.out
@@ -78,6 +78,13 @@ INSERT INTO articles VALUES (47,  7, 'abeyance', 1772);
 INSERT INTO articles VALUES (48,  8, 'alkylic', 18610);
 INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
+-- first, test zero-shard query
+SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+ count 
+-------
+     0
+(1 row)
+
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles WHERE author_id = 10 AND id = 50;

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -78,13 +78,16 @@ INSERT INTO articles VALUES (47,  7, 'abeyance', 1772);
 INSERT INTO articles VALUES (48,  8, 'alkylic', 18610);
 INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
--- first, test zero-shard query
+-- first, test zero-shard SELECT, which should return zero rows
 SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
  count 
 -------
      0
 (1 row)
 
+-- zero-shard modifications should be no-ops but not fail
+UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
+DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles WHERE author_id = 10 AND id = 50;

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -610,9 +610,10 @@ ExtractRangeTableEntryWalker(Node *node, List **rangeTableList)
 
 /*
  * DistributedQueryShardList prunes the shards for the table in the query based
- * on the query's restriction qualifiers, and returns this list. If the function
- * cannot find any shards for the distributed table, it errors out. In other sense,
- * the function errors out or returns a non-empty list.
+ * on the query's restriction qualifiers, and returns this list. It is possible
+ * that all shards will be pruned if a query's restrictions are unsatisfiable.
+ * In that case, this function can return an empty list; however, if the table
+ * being queried has no shards created whatsoever, this function errors out.
  */
 static List *
 DistributedQueryShardList(Query *query)

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -640,9 +640,6 @@ DistributedQueryShardList(Query *query)
 	prunedShardList = PruneShardList(distributedTableId, restrictClauseList,
 									 shardIntervalList);
 
-	/* shouldn't be an empty list, but assert in case something's very wrong */
-	Assert(prunedShardList != NIL);
-
 	return prunedShardList;
 }
 

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -69,6 +69,9 @@ INSERT INTO articles VALUES (48,  8, 'alkylic', 18610);
 INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
 
+-- first, test zero-shard query
+SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+
 -- single-shard tests
 
 -- test simple select for a single row

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -69,8 +69,12 @@ INSERT INTO articles VALUES (48,  8, 'alkylic', 18610);
 INSERT INTO articles VALUES (49,  9, 'anyone', 2681);
 INSERT INTO articles VALUES (50, 10, 'anjanette', 19519);
 
--- first, test zero-shard query
+-- first, test zero-shard SELECT, which should return zero rows
 SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+
+-- zero-shard modifications should be no-ops but not fail
+UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
+DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
 
 -- single-shard tests
 


### PR DESCRIPTION
I added an `Assert` in a9564eb based on the assumption that if all shards are pruned, something is wrong. I neglected to think about any `SELECT` query with unsatisfiable restrictions. Such queries cause the `Assert` to fail.

That said, even without the `Assert`, the behavior is undesirable: we print _cannot execute select over multiple shards_, which is terribly misleading (especially since we _can_ do that).

This change updates names to be clearer that the multi-shard `SELECT` path is really just a possibility in execution and is actually valid for zero shards. I've added a unit test to verify that such zero-shard queries return the correct result (no rows).

Review tasks:

  - [x] See how single-shard logic handles this if I remove the `ereport` call
  - [x] Investigate whether PostgreSQL has short-circuit logic for unsatisfiable queries
  - [x] Look into adding entirely new case for zero-shard queries, see how much extra code it adds
