### PR TITLE
Feature issue#16

### DIFF
--- a/create_shards.c
+++ b/create_shards.c
@@ -80,7 +80,7 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 	char relationKind = '\0';
 	char *partitionColumnName = text_to_cstring(partitionColumnText);
 	char *tableName = text_to_cstring(tableNameText);
-	Var* partitionColumnVar = NULL;
+	Var *partitionColumnVar = NULL;
 
 	/* verify target relation is either regular or foreign table */
 	relationKind = get_rel_relkind(distributedTableId);
@@ -112,7 +112,7 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 			Oid partitionColumnTypeId = partitionColumnVar->vartype;
 
 			ereport(ERROR, (errcode(ERRCODE_UNDEFINED_FUNCTION),
-			          	    errmsg("could not identify a hash function for type %s",
+			                errmsg("could not identify a hash function for type %s",
 			                format_type_be(partitionColumnTypeId)),
 							errdetail("Partition column types must have a hash function "
 									  "defined to use hash partitioning.")));
@@ -137,7 +137,7 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 			         errmsg("could not identify a comparison function for type %s",
 			                format_type_be(partitionColumnTypeId)),
 			         errdetail("Partition column types must have a comparison function "
-			        		   "defined to use range partitioning.")));
+                               "defined to use range partitioning.")));
 		}
 	}
 
@@ -587,7 +587,7 @@ IntegerToText(int32 value)
  *	errors-out if there is no default operator class for the data type of the column.
  */
 Oid
-SupportFunctionForColumn(Var* partitionColumn, Oid accessMethodId,
+SupportFunctionForColumn(Var *partitionColumn, Oid accessMethodId,
 		                 int16 supportFunctionNumber)
 {
 	Oid operatorFamilyId = InvalidOid;

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -58,7 +58,6 @@ static List *ShardIntervalListCache = NIL;
 
 
 /* local function forward declarations */
-static Var * ColumnNameToColumn(Oid relationId, char *columnName);
 static void LoadShardIntervalRow(int64 shardId, Oid *relationId,
 								 char **minValue, char **maxValue);
 static ShardPlacement * TupleToShardPlacement(HeapTuple heapTuple,
@@ -445,7 +444,7 @@ IsDistributedTable(Oid tableId)
  * a Var that represents that column in that relation. This function throws an
  * error if the column doesn't exist or is a system column.
  */
-static Var *
+Var *
 ColumnNameToColumn(Oid relationId, char *columnName)
 {
 	Var *partitionColumn = NULL;

--- a/distribution_metadata.h
+++ b/distribution_metadata.h
@@ -139,6 +139,7 @@ extern List * LoadShardPlacementList(int64 shardId);
 extern Var * PartitionColumn(Oid distributedTableId);
 extern char PartitionType(Oid distributedTableId);
 extern bool IsDistributedTable(Oid tableId);
+extern Var * ColumnNameToColumn(Oid relationId, char *columnName);
 extern void InsertPartitionRow(Oid distributedTableId, char partitionType,
 							   text *partitionKeyText);
 extern void InsertShardRow(Oid distributedTableId, uint64 shardId, char shardStorage,

--- a/distribution_metadata.h
+++ b/distribution_metadata.h
@@ -59,6 +59,7 @@
 
 /* denotes partition type of the distributed table */
 #define HASH_PARTITION_TYPE 'h'
+#define RANGE_PARTITION_TYPE 'r'
 
 /* human-readable names for addressing columns of partition table */
 #define PARTITION_TABLE_ATTRIBUTE_COUNT 3

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -10,12 +10,33 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 	AS 'pg_shard'
 	LANGUAGE C STRICT;
 -- ===================================================================
+-- create test type, operator, operator family and operator class
+-- ===================================================================
+CREATE TYPE test_type AS (
+    i integer
+);
+CREATE FUNCTION test_type_function(test_type, test_type) RETURNS boolean
+AS ' SELECT TRUE;'
+LANGUAGE SQL
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+CREATE OPERATOR = (
+    LEFTARG = test_type,
+    RIGHTARG = test_type,
+    PROCEDURE = test_type_function);
+CREATE OPERATOR FAMILY test_op_family USING hash;
+-- create operator class with no support routine
+CREATE OPERATOR CLASS test_op_family_class
+DEFAULT FOR TYPE test_type USING hash FAMILY test_op_family AS
+OPERATOR 1 =;
+-- ===================================================================
 -- test shard creation functionality
 -- ===================================================================
 CREATE TABLE table_to_distribute (
 	name text,
 	id bigint PRIMARY KEY,
-	data	json
+	json_data json,
+	test_type_data test_type
 );
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id');
@@ -27,10 +48,15 @@ ERROR:  could not find column: bad_column
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 ERROR:  unsupported partition method: r
--- use unsupported partition column
-SELECT master_create_distributed_table('table_to_distribute', 'data');
+-- use unsupported partition column which does not have any default op class
+SELECT master_create_distributed_table('table_to_distribute', 'json_data');
 ERROR:  cannot distribute relation: "table_to_distribute"
-DETAIL:  Column "data" is not eligible to be the distribution column.
+DETAIL:  Column "json_data" does not have a default operator class with the provided partition method.
+HINT:  Try another column as the distribution column.
+-- use unsupported partition column which does not have required support routines
+SELECT master_create_distributed_table('table_to_distribute', 'test_type_data');
+ERROR:  cannot distribute relation: "table_to_distribute"
+DETAIL:  Hash operator is not defined for the data type of column "test_type_data".
 HINT:  Try another column as the distribution column.
 -- distribute table and inspect side effects
 SELECT master_create_distributed_table('table_to_distribute', 'name');

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -14,7 +14,8 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 -- ===================================================================
 CREATE TABLE table_to_distribute (
 	name text,
-	id bigint PRIMARY KEY
+	id bigint PRIMARY KEY,
+	data	json
 );
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id');
@@ -26,6 +27,11 @@ ERROR:  could not find column: bad_column
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 ERROR:  unsupported partition method: r
+-- use unsupported partition column
+SELECT master_create_distributed_table('table_to_distribute', 'data');
+ERROR:  cannot distribute relation: "table_to_distribute"
+DETAIL:  Column "data" is not eligible to be the distribution column.
+HINT:  Try another column as the distribution column.
 -- distribute table and inspect side effects
 SELECT master_create_distributed_table('table_to_distribute', 'name');
  master_create_distributed_table 

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -16,14 +16,15 @@ CREATE TYPE dummy_type AS (
     i integer
 );
 CREATE FUNCTION dummy_type_function(dummy_type, dummy_type) RETURNS boolean
-AS ' SELECT TRUE;'
+AS 'SELECT TRUE;'
 LANGUAGE SQL
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 CREATE OPERATOR = (
     LEFTARG = dummy_type,
     RIGHTARG = dummy_type,
-    PROCEDURE = dummy_type_function);
+    PROCEDURE = dummy_type_function
+);
 CREATE OPERATOR FAMILY dummy_op_family USING hash;
 -- create operator class with no support function
 CREATE OPERATOR CLASS dummy_op_family_class
@@ -44,20 +45,18 @@ ERROR:  cannot distribute relation: "table_to_distribute_pkey"
 DETAIL:  Distributed relations must be regular or foreign tables.
 -- use a bad column name
 SELECT master_create_distributed_table('table_to_distribute', 'bad_column');
-ERROR:  could not find column: bad_column
+ERROR:  partition column "bad_column" not found
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
-ERROR:  unsupported partition method: r
+ERROR:  pg_shard only supports hash partitioning
 -- use unsupported partition column which does not have any default op class
 SELECT master_create_distributed_table('table_to_distribute', 'json_data');
-ERROR:  cannot distribute relation: "table_to_distribute"
-DETAIL:  Column "json_data" does not have a default operator class with the provided partition method.
-HINT:  Try another column as the distribution column.
+ERROR:  data type json has no default operator class for specified partition method
+DETAIL:  Partition column types must have a default operator class defined.
 -- use unsupported partition column which does not have required support functions
 SELECT master_create_distributed_table('table_to_distribute', 'test_type_data');
-ERROR:  cannot distribute relation: "table_to_distribute"
-DETAIL:  Hash operator is not defined for the data type of column "test_type_data".
-HINT:  Try another column as the distribution column.
+ERROR:  could not identify a hash function for type dummy_type
+DETAIL:  Partition column types must have a hash function defined to use hash partitioning.
 -- distribute table and inspect side effects
 SELECT master_create_distributed_table('table_to_distribute', 'name');
  master_create_distributed_table 

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -12,22 +12,22 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 -- ===================================================================
 -- create test type, operator, operator family and operator class
 -- ===================================================================
-CREATE TYPE test_type AS (
+CREATE TYPE dummy_type AS (
     i integer
 );
-CREATE FUNCTION test_type_function(test_type, test_type) RETURNS boolean
+CREATE FUNCTION dummy_type_function(dummy_type, dummy_type) RETURNS boolean
 AS ' SELECT TRUE;'
 LANGUAGE SQL
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 CREATE OPERATOR = (
-    LEFTARG = test_type,
-    RIGHTARG = test_type,
-    PROCEDURE = test_type_function);
-CREATE OPERATOR FAMILY test_op_family USING hash;
+    LEFTARG = dummy_type,
+    RIGHTARG = dummy_type,
+    PROCEDURE = dummy_type_function);
+CREATE OPERATOR FAMILY dummy_op_family USING hash;
 -- create operator class with no support routine
-CREATE OPERATOR CLASS test_op_family_class
-DEFAULT FOR TYPE test_type USING hash FAMILY test_op_family AS
+CREATE OPERATOR CLASS dummy_op_family_class
+DEFAULT FOR TYPE dummy_type USING hash FAMILY dummy_op_family AS
 OPERATOR 1 =;
 -- ===================================================================
 -- test shard creation functionality
@@ -36,7 +36,7 @@ CREATE TABLE table_to_distribute (
 	name text,
 	id bigint PRIMARY KEY,
 	json_data json,
-	test_type_data test_type
+	test_type_data dummy_type
 );
 -- use an index instead of table name
 SELECT master_create_distributed_table('table_to_distribute_pkey', 'id');

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -25,7 +25,7 @@ CREATE OPERATOR = (
     RIGHTARG = dummy_type,
     PROCEDURE = dummy_type_function);
 CREATE OPERATOR FAMILY dummy_op_family USING hash;
--- create operator class with no support routine
+-- create operator class with no support function
 CREATE OPERATOR CLASS dummy_op_family_class
 DEFAULT FOR TYPE dummy_type USING hash FAMILY dummy_op_family AS
 OPERATOR 1 =;
@@ -53,7 +53,7 @@ SELECT master_create_distributed_table('table_to_distribute', 'json_data');
 ERROR:  cannot distribute relation: "table_to_distribute"
 DETAIL:  Column "json_data" does not have a default operator class with the provided partition method.
 HINT:  Try another column as the distribution column.
--- use unsupported partition column which does not have required support routines
+-- use unsupported partition column which does not have required support functions
 SELECT master_create_distributed_table('table_to_distribute', 'test_type_data');
 ERROR:  cannot distribute relation: "table_to_distribute"
 DETAIL:  Hash operator is not defined for the data type of column "test_type_data".

--- a/prune_shard_list.c
+++ b/prune_shard_list.c
@@ -52,7 +52,6 @@ static List *OperatorIdCache = NIL;
 
 /* local function forward declarations */
 static Oid LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
-static Oid GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
 static bool SimpleOpExpression(Expr *clause);
 static Node * HashableClauseMutator(Node *originalNode, Var *partitionColumn);
 static bool OpExpressionContainsColumn(OpExpr *operatorExpression, Var *partitionColumn);
@@ -305,7 +304,7 @@ LookupOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
  * GetOperatorByType returns the operator oid for the given type, access
  * method, and strategy number.
  */
-static Oid
+Oid
 GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber)
 {
 	/* Get default operator class from pg_opclass */

--- a/prune_shard_list.h
+++ b/prune_shard_list.h
@@ -46,6 +46,7 @@ typedef struct OperatorIdCacheEntry
 extern List * PruneShardList(Oid relationId, List *whereClauseList,
 							 List *shardIntervalList);
 extern OpExpr * MakeOpExpression(Var *variable, int16 strategyNumber);
+extern Oid GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
 
 
 #endif /* PG_SHARD_PRUNE_SHARD_LIST_H */

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -13,13 +13,38 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 	LANGUAGE C STRICT;
 
 -- ===================================================================
+-- create test type, operator, operator family and operator class
+-- ===================================================================
+CREATE TYPE test_type AS (
+    i integer
+);
+
+CREATE FUNCTION test_type_function(test_type, test_type) RETURNS boolean
+AS ' SELECT TRUE;'
+LANGUAGE SQL
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OPERATOR = (
+    LEFTARG = test_type,
+    RIGHTARG = test_type,
+    PROCEDURE = test_type_function);
+CREATE OPERATOR FAMILY test_op_family USING hash;
+
+-- create operator class with no support routine
+CREATE OPERATOR CLASS test_op_family_class
+DEFAULT FOR TYPE test_type USING hash FAMILY test_op_family AS
+OPERATOR 1 =;
+
+-- ===================================================================
 -- test shard creation functionality
 -- ===================================================================
 
 CREATE TABLE table_to_distribute (
 	name text,
 	id bigint PRIMARY KEY,
-	data	json
+	json_data json,
+	test_type_data test_type
 );
 
 -- use an index instead of table name
@@ -31,8 +56,11 @@ SELECT master_create_distributed_table('table_to_distribute', 'bad_column');
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 
--- use unsupported partition column
-SELECT master_create_distributed_table('table_to_distribute', 'data');
+-- use unsupported partition column which does not have any default op class
+SELECT master_create_distributed_table('table_to_distribute', 'json_data');
+
+-- use unsupported partition column which does not have required support routines
+SELECT master_create_distributed_table('table_to_distribute', 'test_type_data');
 
 -- distribute table and inspect side effects
 SELECT master_create_distributed_table('table_to_distribute', 'name');

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -18,7 +18,8 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 
 CREATE TABLE table_to_distribute (
 	name text,
-	id bigint PRIMARY KEY
+	id bigint PRIMARY KEY,
+	data	json
 );
 
 -- use an index instead of table name
@@ -29,6 +30,9 @@ SELECT master_create_distributed_table('table_to_distribute', 'bad_column');
 
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
+
+-- use unsupported partition column
+SELECT master_create_distributed_table('table_to_distribute', 'data');
 
 -- distribute table and inspect side effects
 SELECT master_create_distributed_table('table_to_distribute', 'name');

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -15,25 +15,25 @@ CREATE FUNCTION create_table_then_fail(cstring, integer)
 -- ===================================================================
 -- create test type, operator, operator family and operator class
 -- ===================================================================
-CREATE TYPE test_type AS (
+CREATE TYPE dummy_type AS (
     i integer
 );
 
-CREATE FUNCTION test_type_function(test_type, test_type) RETURNS boolean
+CREATE FUNCTION dummy_type_function(dummy_type, dummy_type) RETURNS boolean
 AS ' SELECT TRUE;'
 LANGUAGE SQL
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 CREATE OPERATOR = (
-    LEFTARG = test_type,
-    RIGHTARG = test_type,
-    PROCEDURE = test_type_function);
-CREATE OPERATOR FAMILY test_op_family USING hash;
+    LEFTARG = dummy_type,
+    RIGHTARG = dummy_type,
+    PROCEDURE = dummy_type_function);
+CREATE OPERATOR FAMILY dummy_op_family USING hash;
 
 -- create operator class with no support routine
-CREATE OPERATOR CLASS test_op_family_class
-DEFAULT FOR TYPE test_type USING hash FAMILY test_op_family AS
+CREATE OPERATOR CLASS dummy_op_family_class
+DEFAULT FOR TYPE dummy_type USING hash FAMILY dummy_op_family AS
 OPERATOR 1 =;
 
 -- ===================================================================
@@ -44,7 +44,7 @@ CREATE TABLE table_to_distribute (
 	name text,
 	id bigint PRIMARY KEY,
 	json_data json,
-	test_type_data test_type
+	test_type_data dummy_type
 );
 
 -- use an index instead of table name

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -31,7 +31,7 @@ CREATE OPERATOR = (
     PROCEDURE = dummy_type_function);
 CREATE OPERATOR FAMILY dummy_op_family USING hash;
 
--- create operator class with no support routine
+-- create operator class with no support function
 CREATE OPERATOR CLASS dummy_op_family_class
 DEFAULT FOR TYPE dummy_type USING hash FAMILY dummy_op_family AS
 OPERATOR 1 =;
@@ -59,7 +59,7 @@ SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 -- use unsupported partition column which does not have any default op class
 SELECT master_create_distributed_table('table_to_distribute', 'json_data');
 
--- use unsupported partition column which does not have required support routines
+-- use unsupported partition column which does not have required support functions
 SELECT master_create_distributed_table('table_to_distribute', 'test_type_data');
 
 -- distribute table and inspect side effects

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -20,7 +20,7 @@ CREATE TYPE dummy_type AS (
 );
 
 CREATE FUNCTION dummy_type_function(dummy_type, dummy_type) RETURNS boolean
-AS ' SELECT TRUE;'
+AS 'SELECT TRUE;'
 LANGUAGE SQL
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
@@ -28,7 +28,8 @@ RETURNS NULL ON NULL INPUT;
 CREATE OPERATOR = (
     LEFTARG = dummy_type,
     RIGHTARG = dummy_type,
-    PROCEDURE = dummy_type_function);
+    PROCEDURE = dummy_type_function
+);
 CREATE OPERATOR FAMILY dummy_op_family USING hash;
 
 -- create operator class with no support function


### PR DESCRIPTION
This pull request aims to prevent tables to be distributed with columns that cannot be used as distribution column.

fixes #16

**Code Review Tasks**

  - [x] Remove `get_attnum` section and replace with call to `ColumnNameToColumn`
  - [x] Rewrite `GetSupportRoutine` as `SupportFunctionForColumn` and make it take a `Var *`
  - [x] Move check for default operator class into `SupportFunctionForColumn`
  - [x] Update error codes, messages, and codes as specified
  - [x] Reduce variable scope as much as possible
  - [x] Fix SQL formatting issues in test
