### PR TITLE
Tweak Makefile version detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,22 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
-# Build the 9.3- or 9.4-derived ruleutils, depending upon active version
+# Earlier versions may not define MAJORVERSION
+ifndef MAJORVERSION
+    MAJORVERSION := $(basename $(VERSION))
+endif
+
+# Determine whether to use 9.3- or 9.4-derived ruleutils
 ifneq (,$(findstring $(MAJORVERSION), 9.3))
 	RULEUTILS_IMPL := ruleutils_93.c
-else ifneq (,$(findstring $(MAJORVERSION), 9.4))
+endif
+ifneq (,$(findstring $(MAJORVERSION), 9.4))
 	RULEUTILS_IMPL := ruleutils_94.c
-else
-	# Error out if too old altogether
-	$(error PostgreSQL 9.3 or 9.4 is required to compile this extension)
+endif
+
+# If neither 9.3 nor 9.4 was detected, abort
+ifeq (,$(RULEUTILS_IMPL))
+    $(error PostgreSQL 9.3 or 9.4 is required to compile this extension)
 endif
 
 # Same as implicit %.o rule, except building ruleutils.o from -93/94


### PR DESCRIPTION
As reported [here][1], older versions of make don't support `else if`-like constructs, so we need to just use plain `if` statements or nest them if absolutely necessary.

Additionally, we were missing the logic to set `MAJORVERSION` based on `VERSION` if the former is not present. Older PostgreSQL versions need this, so I've added it.

Fixes #83.

[1]: https://groups.google.com/d/msg/pg_shard-users/N92qnf-Cj6A/lqPKw_9ekfUJ