### PR TITLE
Modify Citus metadata sync to be idempotent

### DIFF
--- a/expected/citus_metadata_sync.out
+++ b/expected/citus_metadata_sync.out
@@ -1,6 +1,9 @@
 -- ===================================================================
 -- test metadata sync functionality
 -- ===================================================================
+-- declare some variables for clarity
+\set finalized 1
+\set inactive 3
 -- set up a table and "distribute" it manually
 CREATE TABLE set_of_ids ( id bigint );
 INSERT INTO pgs_distribution_metadata.shard
@@ -11,8 +14,8 @@ VALUES
 INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES
-	(101, 'cluster-worker-01', 5432, 1, 0),
-	(102, 'cluster-worker-02', 5433, 2, 0);
+	(101, 'cluster-worker-01', 5432, 1, :finalized),
+	(102, 'cluster-worker-02', 5433, 2, :finalized);
 INSERT INTO pgs_distribution_metadata.partition (relation_id, partition_method, key)
 VALUES
 	('set_of_ids'::regclass, 'h', 'id');
@@ -83,7 +86,71 @@ WHERE  shardid IN (SELECT shardid
 ORDER BY nodename;
  shardid | shardstate | shardlength |     nodename      | nodeport 
 ---------+------------+-------------+-------------------+----------
-       1 |          0 |           0 | cluster-worker-01 |     5432
-       2 |          0 |           0 | cluster-worker-02 |     5433
+       1 |          1 |           0 | cluster-worker-01 |     5432
+       2 |          1 |           0 | cluster-worker-02 |     5433
 (2 rows)
+
+-- subsequent sync should have no effect
+SELECT sync_table_metadata_to_citus('set_of_ids');
+ sync_table_metadata_to_citus 
+------------------------------
+ 
+(1 row)
+
+SELECT partmethod, partkey
+FROM   pg_dist_partition
+WHERE  logicalrelid = 'set_of_ids'::regclass;
+ partmethod |                                                        partkey                                                         
+------------+------------------------------------------------------------------------------------------------------------------------
+ h          | {VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
+(1 row)
+
+SELECT shardid, shardstorage, shardalias, shardminvalue, shardmaxvalue
+FROM   pg_dist_shard
+WHERE  logicalrelid = 'set_of_ids'::regclass
+ORDER BY shardid;
+ shardid | shardstorage | shardalias | shardminvalue | shardmaxvalue 
+---------+--------------+------------+---------------+---------------
+       1 | t            |            | 0             | 10
+       2 | t            |            | 10            | 20
+(2 rows)
+
+SELECT * FROM pg_dist_shard_placement
+WHERE  shardid IN (SELECT shardid
+				   FROM   pg_dist_shard
+				   WHERE  logicalrelid = 'set_of_ids'::regclass)
+ORDER BY nodename;
+ shardid | shardstate | shardlength |     nodename      | nodeport 
+---------+------------+-------------+-------------------+----------
+       1 |          1 |           0 | cluster-worker-01 |     5432
+       2 |          1 |           0 | cluster-worker-02 |     5433
+(2 rows)
+
+-- mark a placement as unhealthy and add a new one
+UPDATE pgs_distribution_metadata.shard_placement
+SET    shard_state = :inactive
+WHERE  id = 102;
+INSERT INTO pgs_distribution_metadata.shard_placement
+	(id, node_name, node_port, shard_id, shard_state)
+VALUES
+	(103, 'cluster-worker-03', 5434, 1, :finalized);
+-- write latest changes to Citus tables
+SELECT sync_table_metadata_to_citus('set_of_ids');
+ sync_table_metadata_to_citus 
+------------------------------
+ 
+(1 row)
+
+-- should see updated state and new placement
+SELECT * FROM pg_dist_shard_placement
+WHERE  shardid IN (SELECT shardid
+				   FROM   pg_dist_shard
+				   WHERE  logicalrelid = 'set_of_ids'::regclass)
+ORDER BY nodename;
+ shardid | shardstate | shardlength |     nodename      | nodeport 
+---------+------------+-------------+-------------------+----------
+       1 |          1 |           0 | cluster-worker-01 |     5432
+       2 |          3 |           0 | cluster-worker-02 |     5433
+       1 |          1 |           0 | cluster-worker-03 |     5434
+(3 rows)
 

--- a/expected/citus_metadata_sync.out
+++ b/expected/citus_metadata_sync.out
@@ -15,7 +15,9 @@ INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES
 	(101, 'cluster-worker-01', 5432, 1, :finalized),
-	(102, 'cluster-worker-02', 5433, 2, :finalized);
+	(102, 'cluster-worker-02', 5433, 2, :finalized),
+	(103, 'cluster-worker-03', 5434, 1, :finalized),
+	(104, 'cluster-worker-04', 5435, 2, :finalized);
 INSERT INTO pgs_distribution_metadata.partition (relation_id, partition_method, key)
 VALUES
 	('set_of_ids'::regclass, 'h', 'id');
@@ -88,7 +90,9 @@ ORDER BY nodename;
 ---------+------------+-------------+-------------------+----------
        1 |          1 |           0 | cluster-worker-01 |     5432
        2 |          1 |           0 | cluster-worker-02 |     5433
-(2 rows)
+       1 |          1 |           0 | cluster-worker-03 |     5434
+       2 |          1 |           0 | cluster-worker-04 |     5435
+(4 rows)
 
 -- subsequent sync should have no effect
 SELECT sync_table_metadata_to_citus('set_of_ids');
@@ -124,7 +128,9 @@ ORDER BY nodename;
 ---------+------------+-------------+-------------------+----------
        1 |          1 |           0 | cluster-worker-01 |     5432
        2 |          1 |           0 | cluster-worker-02 |     5433
-(2 rows)
+       1 |          1 |           0 | cluster-worker-03 |     5434
+       2 |          1 |           0 | cluster-worker-04 |     5435
+(4 rows)
 
 -- mark a placement as unhealthy and add a new one
 UPDATE pgs_distribution_metadata.shard_placement
@@ -133,7 +139,7 @@ WHERE  id = 102;
 INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES
-	(103, 'cluster-worker-03', 5434, 1, :finalized);
+	(105, 'cluster-worker-05', 5436, 1, :finalized);
 -- write latest changes to Citus tables
 SELECT sync_table_metadata_to_citus('set_of_ids');
  sync_table_metadata_to_citus 
@@ -152,5 +158,7 @@ ORDER BY nodename;
        1 |          1 |           0 | cluster-worker-01 |     5432
        2 |          3 |           0 | cluster-worker-02 |     5433
        1 |          1 |           0 | cluster-worker-03 |     5434
-(3 rows)
+       2 |          1 |           0 | cluster-worker-04 |     5435
+       1 |          1 |           0 | cluster-worker-05 |     5436
+(5 rows)
 

--- a/pg_shard--1.0--1.1.sql
+++ b/pg_shard--1.0--1.1.sql
@@ -12,7 +12,16 @@ AS $sync_table_metadata_to_citus$
 		table_relation_id CONSTANT oid NOT NULL := table_name::regclass::oid;
 		dummy_shard_length CONSTANT bigint := 0;
 	BEGIN
-		-- copy shard placement metadata
+		-- grab lock for upsert
+		LOCK TABLE pg_dist_shard_placement IN EXCLUSIVE MODE;
+
+		-- perform update of shard health
+		UPDATE pg_dist_shard_placement
+		SET    shardstate = shard_placement.shard_state
+		FROM   pgs_distribution_metadata.shard_placement
+		WHERE  shardid = shard_placement.shard_id;
+
+		-- copy new shard placement metadata
 		INSERT INTO pg_dist_shard_placement
 					(shardid,
 					 shardstate,
@@ -25,11 +34,15 @@ AS $sync_table_metadata_to_citus$
 			   node_name,
 			   node_port
 		FROM   pgs_distribution_metadata.shard_placement
-		WHERE  shard_id IN (SELECT id
-							FROM   pgs_distribution_metadata.shard
-							WHERE  relation_id = table_relation_id);
-
-		-- copy shard metadata
+			   LEFT OUTER JOIN pg_dist_shard_placement
+							ON ( shardid = shard_placement.shard_id
+								 AND nodename = shard_placement.node_name
+								 AND nodeport = shard_placement.node_port )
+		WHERE  shardid IS NULL
+			   AND shard_id IN (SELECT id
+								FROM   pgs_distribution_metadata.shard
+								WHERE  relation_id = table_relation_id);
+		-- copy new shard metadata
 		INSERT INTO pg_dist_shard
 					(shardid,
 					 logicalrelid,
@@ -42,9 +55,12 @@ AS $sync_table_metadata_to_citus$
 			   min_value,
 			   max_value
 		FROM   pgs_distribution_metadata.shard
-		WHERE  relation_id = table_relation_id;
+			   LEFT OUTER JOIN pg_dist_shard
+							ON ( shardid = shard.id )
+		WHERE  shardid IS NULL
+			   AND relation_id = table_relation_id;
 
-		-- copy partition metadata, which also converts the partition column to
+		-- copy new partition metadata, which also converts the partition column to
 		-- a node string representation as expected by CitusDB
 		INSERT INTO pg_dist_partition
 					(logicalrelid,
@@ -54,7 +70,10 @@ AS $sync_table_metadata_to_citus$
 			   partition_method,
 			   partition_column_to_node_string(table_relation_id)
 		FROM   pgs_distribution_metadata.partition
-		WHERE  relation_id = table_relation_id;
+			   LEFT OUTER JOIN pg_dist_partition
+							ON ( logicalrelid = partition.relation_id )
+		WHERE  logicalrelid IS NULL
+			   AND relation_id = table_relation_id;
 	END;
 $sync_table_metadata_to_citus$ LANGUAGE 'plpgsql';
 

--- a/pg_shard--1.1.sql
+++ b/pg_shard--1.1.sql
@@ -117,13 +117,14 @@ AS $sync_table_metadata_to_citus$
 			   node_port
 		FROM   pgs_distribution_metadata.shard_placement
 			   LEFT OUTER JOIN pg_dist_shard_placement
-							ON ( shardid = shard_placement.shard_id
-								 AND nodename = shard_placement.node_name
-								 AND nodeport = shard_placement.node_port )
-		WHERE  shardid IS NULL
-			   AND shard_id IN (SELECT id
-								FROM   pgs_distribution_metadata.shard
-								WHERE  relation_id = table_relation_id);
+							ON ( shardid = shard_placement.shard_id AND
+								 nodename = shard_placement.node_name AND
+								 nodeport = shard_placement.node_port )
+		WHERE  shardid IS NULL AND
+			   shard_id IN (SELECT id
+							FROM   pgs_distribution_metadata.shard
+							WHERE  relation_id = table_relation_id);
+
 		-- copy new shard metadata
 		INSERT INTO pg_dist_shard
 					(shardid,
@@ -139,8 +140,8 @@ AS $sync_table_metadata_to_citus$
 		FROM   pgs_distribution_metadata.shard
 			   LEFT OUTER JOIN pg_dist_shard
 							ON ( shardid = shard.id )
-		WHERE  shardid IS NULL
-			   AND relation_id = table_relation_id;
+		WHERE  shardid IS NULL AND
+			   relation_id = table_relation_id;
 
 		-- copy new partition metadata, which also converts the partition column to
 		-- a node string representation as expected by CitusDB
@@ -154,8 +155,8 @@ AS $sync_table_metadata_to_citus$
 		FROM   pgs_distribution_metadata.partition
 			   LEFT OUTER JOIN pg_dist_partition
 							ON ( logicalrelid = partition.relation_id )
-		WHERE  logicalrelid IS NULL
-			   AND relation_id = table_relation_id;
+		WHERE  logicalrelid IS NULL AND
+			   relation_id = table_relation_id;
 	END;
 $sync_table_metadata_to_citus$ LANGUAGE 'plpgsql';
 
@@ -205,7 +206,7 @@ AS $create_insert_proxy_for_table$
 		INTO   STRICT attr_names
 		FROM   pg_attribute
 		WHERE  attrelid = target_table AND
-			   attnum > 0          AND
+			   attnum > 0 AND
 			   NOT attisdropped;
 
 		-- build fully specified column list and USING clause from attr. names

--- a/pg_shard--1.1.sql
+++ b/pg_shard--1.1.sql
@@ -99,7 +99,9 @@ AS $sync_table_metadata_to_citus$
 		UPDATE pg_dist_shard_placement
 		SET    shardstate = shard_placement.shard_state
 		FROM   pgs_distribution_metadata.shard_placement
-		WHERE  shardid = shard_placement.shard_id;
+		WHERE  shardid = shard_placement.shard_id AND
+			   nodename = shard_placement.node_name AND
+			   nodeport = shard_placement.node_port;
 
 		-- copy new shard placement metadata
 		INSERT INTO pg_dist_shard_placement

--- a/pg_shard--1.1.sql
+++ b/pg_shard--1.1.sql
@@ -86,16 +86,25 @@ LANGUAGE C;
 COMMENT ON FUNCTION partition_column_to_node_string(oid)
 		IS 'return textual form of distributed table''s partition column';
 
-CREATE FUNCTION sync_table_metadata_to_citus(table_name text) RETURNS VOID
+-- Syncs rows from the pg_shard distribution metadata related to the specified
+-- table name into the metadata tables used by CitusDB. After a call to this
+-- function for a particular pg_shard table, that table will become usable for
+-- queries within CitusDB. If placement health has changed for given pg_shard
+-- table, calling this function an additional time will propagate those health
+-- changes to the CitusDB metadata tables.
+CREATE FUNCTION sync_table_metadata_to_citus(table_name text)
+RETURNS void
 AS $sync_table_metadata_to_citus$
 	DECLARE
 		table_relation_id CONSTANT oid NOT NULL := table_name::regclass::oid;
 		dummy_shard_length CONSTANT bigint := 0;
 	BEGIN
-		-- grab lock for upsert
+		-- grab lock to ensure single writer for upsert
 		LOCK TABLE pg_dist_shard_placement IN EXCLUSIVE MODE;
 
-		-- perform update of shard health
+		-- First, update the health of shard placement rows already copied
+		-- from pg_shard to CitusDB. Health is the only mutable attribute,
+		-- so it is presently the only one needing the UPDATE treatment.
 		UPDATE pg_dist_shard_placement
 		SET    shardstate = shard_placement.shard_state
 		FROM   pgs_distribution_metadata.shard_placement
@@ -103,7 +112,7 @@ AS $sync_table_metadata_to_citus$
 			   nodename = shard_placement.node_name AND
 			   nodeport = shard_placement.node_port;
 
-		-- copy new shard placement metadata
+		-- copy pg_shard placement rows not yet in CitusDB's metadata tables
 		INSERT INTO pg_dist_shard_placement
 					(shardid,
 					 shardstate,
@@ -125,7 +134,7 @@ AS $sync_table_metadata_to_citus$
 							FROM   pgs_distribution_metadata.shard
 							WHERE  relation_id = table_relation_id);
 
-		-- copy new shard metadata
+		-- copy pg_shard shard rows not yet in CitusDB's metadata tables
 		INSERT INTO pg_dist_shard
 					(shardid,
 					 logicalrelid,
@@ -143,8 +152,10 @@ AS $sync_table_metadata_to_citus$
 		WHERE  shardid IS NULL AND
 			   relation_id = table_relation_id;
 
-		-- copy new partition metadata, which also converts the partition column to
-		-- a node string representation as expected by CitusDB
+		-- Finally, copy pg_shard partition rows not yet in CitusDB's metadata
+		-- tables. CitusDB uses a textual form of a Var node representing the
+		-- partition column, so we must use a special function to transform the
+		-- representation used by pg_shard (which is just the column name).
 		INSERT INTO pg_dist_partition
 					(logicalrelid,
 					 partmethod,

--- a/sql/citus_metadata_sync.sql
+++ b/sql/citus_metadata_sync.sql
@@ -19,7 +19,9 @@ INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES
 	(101, 'cluster-worker-01', 5432, 1, :finalized),
-	(102, 'cluster-worker-02', 5433, 2, :finalized);
+	(102, 'cluster-worker-02', 5433, 2, :finalized),
+	(103, 'cluster-worker-03', 5434, 1, :finalized),
+	(104, 'cluster-worker-04', 5435, 2, :finalized);
 
 INSERT INTO pgs_distribution_metadata.partition (relation_id, partition_method, key)
 VALUES
@@ -101,7 +103,7 @@ WHERE  id = 102;
 INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES
-	(103, 'cluster-worker-03', 5434, 1, :finalized);
+	(105, 'cluster-worker-05', 5436, 1, :finalized);
 
 -- write latest changes to Citus tables
 SELECT sync_table_metadata_to_citus('set_of_ids');


### PR DESCRIPTION
A customer noticed this function could not be called more than once without error. Now calling it more than once has the same effect as calling it once. In addition, if a shard placement's state has changed since the most recent call, an additional call will update the placement state in CitusDB's view.

Added a unit test to verify these cases.

For an explanation of the algorithm in use here, read the _Bulk upsert with lock_ section in [this Stack Overflow answer](http://stackoverflow.com/a/17267423).

**Code review tasks**

  - [x] Fix `JOIN` condition on `UPDATE` to consider node names and ports as well as shard identifier
  - [x] Augment test to place shards on multiple nodes (which would fail without the above change)
  - [x] Clarify comments
  - [x] See whether we can combine any lines, maybe rework formatting
