### PR TITLE
Bugfix volalite functions#47

### DIFF
--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -77,6 +77,9 @@ ERROR:  cannot plan sharded modification containing values which are not constan
 -- commands with expressions that cannot be collapsed are unsupported
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
+-- commands with mutable or volitale functions 
+DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
+ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
 -- commands with multiple rows are unsupported
 INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);
 ERROR:  cannot perform distributed planning for the given query

--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -80,7 +80,7 @@ ERROR:  cannot plan sharded modification containing values which are not constan
 -- commands with mutable functions in their quals
 DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
 ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
--- commands with mutable but non-volatilte functions in their quals
+-- commands with mutable but non-volatilte functions(ie: stable func.) in their quals
 DELETE FROM limit_orders WHERE id = 246 AND placed_at = current_timestamp;
 ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
 -- commands with multiple rows are unsupported

--- a/expected/modifications.out.tmpl
+++ b/expected/modifications.out.tmpl
@@ -77,8 +77,11 @@ ERROR:  cannot plan sharded modification containing values which are not constan
 -- commands with expressions that cannot be collapsed are unsupported
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
--- commands with mutable or volitale functions 
+-- commands with mutable functions in their quals
 DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
+ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
+-- commands with mutable but non-volatilte functions in their quals
+DELETE FROM limit_orders WHERE id = 246 AND placed_at = current_timestamp;
 ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
 -- commands with multiple rows are unsupported
 INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -395,7 +395,6 @@ ErrorIfQueryNotSupported(Query *queryTree)
 	bool hasNonConstTargetEntryExprs = false;
 	bool hasNonConstQualExprs = false;
 	bool specifiesPartitionValue = false;
-	Node *whereClause = NULL;
 
 	CmdType commandType = queryTree->commandType;
 	Assert(commandType == CMD_SELECT || commandType == CMD_INSERT ||
@@ -517,6 +516,7 @@ ErrorIfQueryNotSupported(Query *queryTree)
 	if (commandType == CMD_INSERT || commandType == CMD_UPDATE ||
 		commandType == CMD_DELETE)
 	{
+		FromExpr *joinTree = NULL;
 		ListCell *targetEntryCell = NULL;
 
 		foreach(targetEntryCell, queryTree->targetList)
@@ -540,10 +540,8 @@ ErrorIfQueryNotSupported(Query *queryTree)
 			}
 		}
 
-		whereClause = ((queryTree->jointree == NULL) ?
-					   NULL : queryTree->jointree->quals);
-		if (contain_mutable_functions(whereClause) ||
-			contain_volatile_functions(whereClause))
+		joinTree = queryTree->jointree;
+		if (joinTree != NULL && contain_mutable_functions(joinTree->quals))
 		{
 			hasNonConstQualExprs = true;
 		}

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -541,7 +541,7 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		}
 
 		whereClause = ((queryTree->jointree == NULL) ?
-						NULL : queryTree->jointree->quals);
+					   NULL : queryTree->jointree->quals);
 		if (contain_mutable_functions(whereClause) ||
 			contain_volatile_functions(whereClause))
 		{

--- a/sql/modifications.sql
+++ b/sql/modifications.sql
@@ -57,7 +57,7 @@ INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 -- commands with mutable functions in their quals
 DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
 
--- commands with mutable but non-volatilte functions in their quals
+-- commands with mutable but non-volatilte functions(ie: stable func.) in their quals
 DELETE FROM limit_orders WHERE id = 246 AND placed_at = current_timestamp;
 
 -- commands with multiple rows are unsupported

--- a/sql/modifications.sql
+++ b/sql/modifications.sql
@@ -54,6 +54,9 @@ INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:
 -- commands with expressions that cannot be collapsed are unsupported
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 
+-- commands with mutable or volitale functions 
+DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
+
 -- commands with multiple rows are unsupported
 INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);
 

--- a/sql/modifications.sql
+++ b/sql/modifications.sql
@@ -54,8 +54,11 @@ INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:
 -- commands with expressions that cannot be collapsed are unsupported
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 
--- commands with mutable or volitale functions 
+-- commands with mutable functions in their quals
 DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
+
+-- commands with mutable but non-volatilte functions in their quals
+DELETE FROM limit_orders WHERE id = 246 AND placed_at = current_timestamp;
 
 -- commands with multiple rows are unsupported
 INSERT INTO limit_orders VALUES (DEFAULT), (DEFAULT);


### PR DESCRIPTION
This pull request prevents WHERE clause statements to have VOLATILE or MUTABLE functions.

Fixes #47

**Review tasks**

  - [x] Fix comment in test
  - [x] Rework area that used ternary expression
  - [x] Remove call to `contain_volatile_functions`
  - [x] Add test with mutable but not volatile function such as `current_timestamp`