### PR TITLE
CitusDB metadata interoperability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: apt
 env:
   global:
     - enable_coverage=yes
+    - PG_PRELOAD=pg_shard
   matrix:
     - PGVERSION=9.3
     - PGVERSION=9.4

--- a/citus_metadata_sync.h
+++ b/citus_metadata_sync.h
@@ -19,6 +19,8 @@
 
 /* function declarations for syncing metadata with CitusDB */
 extern Datum partition_column_to_node_string(PG_FUNCTION_ARGS);
+extern Datum column_name_to_column(PG_FUNCTION_ARGS);
+extern Datum column_to_column_name(PG_FUNCTION_ARGS);
 
 
 #endif /* PG_SHARD_CITUS_METADATA_SYNC_H */

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -23,6 +23,7 @@
 #include "access/htup.h"
 #include "access/tupdesc.h"
 #include "executor/spi.h"
+#include "catalog/catalog.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "nodes/makefuncs.h"
@@ -374,6 +375,7 @@ PartitionType(Oid distributedTableId)
 bool
 IsDistributedTable(Oid tableId)
 {
+	Oid tableNamespaceOid = get_rel_namespace(tableId);
 	Oid metadataNamespaceOid = get_namespace_oid("pgs_distribution_metadata", false);
 	Oid partitionMetadataTableOid = get_relname_relid("partition", metadataNamespaceOid);
 	bool isDistributedTable = false;
@@ -386,7 +388,7 @@ IsDistributedTable(Oid tableId)
 	 * The query below hits the partition metadata table, so if we don't detect
 	 * that and short-circuit, we'll get infinite recursion in the planner.
 	 */
-	if (tableId == partitionMetadataTableOid)
+	if (IsSystemNamespace(tableNamespaceOid) || tableId == partitionMetadataTableOid)
 	{
 		return false;
 	}

--- a/distribution_metadata.h
+++ b/distribution_metadata.h
@@ -51,6 +51,7 @@
 #define TLIST_NUM_SHARD_PLACEMENT_NODE_PORT 5
 
 /* denotes partition type of the distributed table */
+#define APPEND_PARTITION_TYPE 'a'
 #define HASH_PARTITION_TYPE 'h'
 #define RANGE_PARTITION_TYPE 'r'
 

--- a/expected/citus_metadata_sync.out
+++ b/expected/citus_metadata_sync.out
@@ -86,6 +86,7 @@ CREATE TABLE pg_dist_shard_placement (
 ) WITH OIDS;
 -- sync metadata and verify it has transferred
 SELECT sync_table_metadata_to_citus('set_of_ids');
+WARNING:  sync_table_metadata_to_citus is deprecated and will be removed in a future version
  sync_table_metadata_to_citus 
 ------------------------------
  
@@ -124,6 +125,7 @@ ORDER BY nodename;
 
 -- subsequent sync should have no effect
 SELECT sync_table_metadata_to_citus('set_of_ids');
+WARNING:  sync_table_metadata_to_citus is deprecated and will be removed in a future version
  sync_table_metadata_to_citus 
 ------------------------------
  
@@ -170,6 +172,7 @@ VALUES
 	(105, 'cluster-worker-05', 5436, 1, :finalized);
 -- write latest changes to CitusDB tables
 SELECT sync_table_metadata_to_citus('set_of_ids');
+WARNING:  sync_table_metadata_to_citus is deprecated and will be removed in a future version
  sync_table_metadata_to_citus 
 ------------------------------
  

--- a/expected/citus_metadata_sync.out
+++ b/expected/citus_metadata_sync.out
@@ -36,6 +36,29 @@ SELECT partition_column_to_node_string('set_of_ids'::regclass);
  {VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
 (1 row)
 
+-- should get error for system or non-existent column
+SELECT column_name_to_column('set_of_ids'::regclass, 'ctid');
+ERROR:  column "ctid" of relation "set_of_ids" is a system column
+SELECT column_name_to_column('set_of_ids'::regclass, 'non_existent');
+ERROR:  column "non_existent" of relation "set_of_ids" does not exist
+-- should get node representation for valid column
+SELECT column_name_to_column('set_of_ids'::regclass, 'id') AS column_var
+\gset
+SELECT replace(:'column_var', ':varattno 1', ':varattno -1') AS ctid_var,
+	   replace(:'column_var', ':varattno 1', ':varattno 2') AS non_ext_var
+\gset
+-- should get error for system or non-existent column
+SELECT column_to_column_name('set_of_ids'::regclass, :'ctid_var');
+ERROR:  attribute -1 of relation "set_of_ids" is a system column
+SELECT column_to_column_name('set_of_ids'::regclass, :'non_ext_var');
+ERROR:  attribute 2 of relation "set_of_ids" does not exist
+-- should get node representation for valid column
+SELECT column_to_column_name('set_of_ids'::regclass, :'column_var');
+ column_to_column_name 
+-----------------------
+ id
+(1 row)
+
 -- create subset of CitusDB metadata schema
 CREATE TABLE pg_dist_partition (
 	logicalrelid oid NOT NULL,

--- a/expected/citus_metadata_sync.out
+++ b/expected/citus_metadata_sync.out
@@ -36,6 +36,10 @@ SELECT partition_column_to_node_string('set_of_ids'::regclass);
  {VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
 (1 row)
 
+-- should get error for column names that are too long
+SELECT column_name_to_column('set_of_ids'::regclass, repeat('a', 1024));
+ERROR:  column name too long
+DETAIL:  Column name must be less than 64 characters.
 -- should get error for system or non-existent column
 SELECT column_name_to_column('set_of_ids'::regclass, 'ctid');
 ERROR:  column "ctid" of relation "set_of_ids" is a system column
@@ -159,7 +163,7 @@ ORDER BY nodename;
 -- mark a placement as unhealthy and add a new one
 UPDATE pgs_distribution_metadata.shard_placement
 SET    shard_state = :inactive
-WHERE  id = 102;
+WHERE  node_name = 'cluster-worker-02';
 INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)
 VALUES

--- a/expected/distribution_metadata.out
+++ b/expected/distribution_metadata.out
@@ -46,11 +46,11 @@ CREATE FUNCTION create_healthy_local_shard_placement_row(bigint)
 	AS 'pg_shard'
 	LANGUAGE C STRICT;
 CREATE FUNCTION delete_shard_placement_row(bigint)
-	RETURNS void
+	RETURNS bool
 	AS 'pg_shard'
 	LANGUAGE C STRICT;
 CREATE FUNCTION update_shard_placement_row_state(bigint, int)
-	RETURNS void
+	RETURNS bool
 	AS 'pg_shard'
 	LANGUAGE C STRICT;
 CREATE FUNCTION acquire_shared_shard_lock(bigint)
@@ -164,18 +164,6 @@ SELECT partition_column_id('events');
                    2
 (1 row)
 
-BEGIN;
-	UPDATE pgs_distribution_metadata.partition
-	SET    key = REPEAT('a', 1024)
-	WHERE  relation_id = 'events' :: regclass;
-	---- should see error that partition column is too long
-	SELECT Partition_column_id('events');
-ERROR:  column name too long
-DETAIL:  Column name must be less than 64 characters.
-ROLLBACK;
--- should see error (catalog is not distributed)
-SELECT partition_column_id('pg_type');
-ERROR:  no partition column is defined for relation "pg_type"
 -- should see hash partition type and fail for non-distributed tables
 SELECT partition_type('events');
  partition_type 
@@ -284,17 +272,18 @@ WHERE id = :new_shard_id;
 -- add a placement and manually inspect row
 SELECT create_healthy_local_shard_placement_row(:new_shard_id) AS new_placement_id
 \gset
-SELECT * FROM pgs_distribution_metadata.shard_placement WHERE id = :new_placement_id;
- id | shard_id | shard_state | node_name | node_port 
-----+----------+-------------+-----------+-----------
-  1 |    10000 |           1 | localhost |      5432
+SELECT shard_state, node_name, node_port FROM pgs_distribution_metadata.shard_placement
+WHERE id = :new_placement_id;
+ shard_state | node_name | node_port 
+-------------+-----------+-----------
+           1 | localhost |      5432
 (1 row)
 
 -- mark it as unhealthy and inspect
 SELECT update_shard_placement_row_state(:new_placement_id, 3);
  update_shard_placement_row_state 
 ----------------------------------
- 
+ t
 (1 row)
 
 SELECT shard_state FROM pgs_distribution_metadata.shard_placement
@@ -308,7 +297,7 @@ WHERE id = :new_placement_id;
 SELECT delete_shard_placement_row(:new_placement_id);
  delete_shard_placement_row 
 ----------------------------
- 
+ t
 (1 row)
 
 SELECT COUNT(*) FROM pgs_distribution_metadata.shard_placement
@@ -320,9 +309,17 @@ WHERE id = :new_placement_id;
 
 -- deleting or updating a non-existent row should fail
 SELECT delete_shard_placement_row(:new_placement_id);
-ERROR:  shard placement with ID 1 does not exist
+ delete_shard_placement_row 
+----------------------------
+ f
+(1 row)
+
 SELECT update_shard_placement_row_state(:new_placement_id, 3);
-ERROR:  shard placement with ID 1 does not exist
+ update_shard_placement_row_state 
+----------------------------------
+ f
+(1 row)
+
 -- now we'll even test our lock methods...
 -- use transaction to bound how long we hold the lock
 BEGIN;

--- a/expected/init.out
+++ b/expected/init.out
@@ -9,3 +9,16 @@ AS 'pg_shard'
 LANGUAGE C STRICT;
 CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler;
 CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw;
+-- Set pg_shard sequence to start at same number as that used by CitusDB.
+-- This makes testing easier, since shard IDs will match.
+DO $$
+BEGIN
+	BEGIN
+		PERFORM setval('pgs_distribution_metadata.shard_id_sequence',
+					   102008, false);
+	EXCEPTION
+	WHEN undefined_table THEN
+		-- do nothing
+	END;
+END;
+$$;

--- a/expected/modifications.out
+++ b/expected/modifications.out
@@ -211,8 +211,11 @@ WITH limit_order_placements AS (
 		AND    s.relation_id = 'limit_orders'::regclass
 	)
 INSERT INTO pgs_distribution_metadata.shard_placement
-SELECT nextval('pgs_distribution_metadata.shard_placement_id_sequence'),
-	   shard_id,
+			(shard_id,
+			 shard_state,
+			 node_name,
+			 node_port)
+SELECT shard_id,
 	   shard_state,
 	   'badhost',
 	   54321

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -89,7 +89,7 @@ SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
      0
 (1 row)
 
--- zero-shard modifications should be no-ops but not fail
+-- zero-shard modifications should be no-ops in pg_shard, fail in CitusDB
 UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
 DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
 -- single-shard tests
@@ -201,11 +201,6 @@ DETAIL:  Joins are not supported in distributed queries.
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 ERROR:  cannot perform distributed planning for the given query
 DETAIL:  Joins are not supported in distributed queries.
--- test CitusDB code path (this will error out in normal PostgreSQL)
-SELECT sync_table_metadata_to_citus('articles');
-ERROR:  relation "pg_dist_shard_placement" does not exist
-CONTEXT:  SQL statement "LOCK TABLE pg_dist_shard_placement IN EXCLUSIVE MODE"
-PL/pgSQL function sync_table_metadata_to_citus(text) line 7 at SQL statement
 -- with normal PostgreSQL, expect error about CitusDB being missing
 -- with CitusDB, expect an error about JOINing local table with distributed
 SET pg_shard.use_citusdb_select_logic TO true;
@@ -257,7 +252,8 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles
 -- cross-shard queries on a foreign table should fail
 -- we'll just point the article shards to a foreign table
 BEGIN;
-	CREATE FOREIGN TABLE foreign_articles (author_id bigint) SERVER fake_fdw_server;
+	CREATE FOREIGN TABLE foreign_articles (id bigint, author_id bigint)
+	SERVER fake_fdw_server;
 	UPDATE pgs_distribution_metadata.partition
 	SET relation_id='foreign_articles'::regclass
 	WHERE relation_id='articles'::regclass;
@@ -272,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10038 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -89,9 +89,11 @@ SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
      0
 (1 row)
 
--- zero-shard modifications should be no-ops but not fail
+-- zero-shard modifications should be no-ops in pg_shard, fail in CitusDB
 UPDATE articles SET title = '' WHERE author_id = 1 AND author_id = 2;
+ERROR:  cannot execute UPDATE on a distributed table on master node
 DELETE FROM articles WHERE author_id = 1 AND author_id = 2;
+ERROR:  cannot execute DELETE on a distributed table on master node
 -- single-shard tests
 -- test simple select for a single row
 SELECT * FROM articles WHERE author_id = 10 AND id = 50;
@@ -201,13 +203,6 @@ DETAIL:  Joins are not supported in distributed queries.
 SELECT * FROM  (articles INNER JOIN authors ON articles.id = authors.id);
 ERROR:  cannot perform distributed planning for the given query
 DETAIL:  Joins are not supported in distributed queries.
--- test CitusDB code path (this will error out in normal PostgreSQL)
-SELECT sync_table_metadata_to_citus('articles');
- sync_table_metadata_to_citus 
-------------------------------
- 
-(1 row)
-
 -- with normal PostgreSQL, expect error about CitusDB being missing
 -- with CitusDB, expect an error about JOINing local table with distributed
 SET pg_shard.use_citusdb_select_logic TO true;
@@ -257,7 +252,8 @@ SELECT author_id, sum(word_count) AS corpus_size FROM articles
 -- cross-shard queries on a foreign table should fail
 -- we'll just point the article shards to a foreign table
 BEGIN;
-	CREATE FOREIGN TABLE foreign_articles (author_id bigint) SERVER fake_fdw_server;
+	CREATE FOREIGN TABLE foreign_articles (id bigint, author_id bigint)
+	SERVER fake_fdw_server;
 	UPDATE pgs_distribution_metadata.partition
 	SET relation_id='foreign_articles'::regclass
 	WHERE relation_id='articles'::regclass;
@@ -272,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10038 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/pg_shard--1.1--1.2.sql
+++ b/pg_shard--1.1--1.2.sql
@@ -1,13 +1,242 @@
--- add default values to id columns
-ALTER TABLE pgs_distribution_metadata.shard
-	ALTER COLUMN id
-	SET DEFAULT nextval('pgs_distribution_metadata.shard_id_sequence');
-ALTER TABLE pgs_distribution_metadata.shard_placement
-	ALTER COLUMN id
-	SET DEFAULT nextval('pgs_distribution_metadata.shard_placement_id_sequence');
+-- needed in our views
+CREATE FUNCTION column_to_column_name(table_oid oid, column_var text)
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE STRICT;
 
--- associate sequences with their columns
-ALTER SEQUENCE pgs_distribution_metadata.shard_id_sequence
-	OWNED BY pgs_distribution_metadata.shard.id;
-ALTER SEQUENCE pgs_distribution_metadata.shard_placement_id_sequence
-	OWNED BY pgs_distribution_metadata.shard_placement.id;
+CREATE FUNCTION column_name_to_column(table_oid oid, column_name text)
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE STRICT;
+
+DO $$
+DECLARE
+	use_citus_metadata boolean := false;
+	relation_name oid;
+BEGIN
+	BEGIN
+		PERFORM 'pg_catalog.pg_dist_partition'::regclass;
+		use_citus_metadata = true;
+	EXCEPTION
+		WHEN undefined_table THEN
+			use_citus_metadata = false;
+	END;
+
+	IF use_citus_metadata THEN
+		-- just in case, lock everyone out of pg_shard partitions
+		LOCK TABLE pgs_distribution_metadata.partition IN EXCLUSIVE MODE;
+		FOR relation_name IN SELECT relation_id::regclass::text
+		FROM pgs_distribution_metadata.partition LOOP
+			PERFORM sync_table_metadata_to_citus(relation_id::regclass);
+		END LOOP;
+
+		DROP TABLE pgs_distribution_metadata.partition,
+				   pgs_distribution_metadata.shard,
+				   pgs_distribution_metadata.shard_placement;
+
+		CREATE FUNCTION adapt_and_insert_shard() RETURNS TRIGGER AS $aais$
+		BEGIN
+			IF NEW.id IS NULL THEN
+				NEW.id = nextval('pg_dist_shardid_seq');
+			END IF;
+
+			INSERT INTO pg_dist_shard
+						(logicalrelid,
+						 shardid,
+						 shardstorage,
+						 shardalias,
+						 shardminvalue,
+						 shardmaxvalue)
+			VALUES      (NEW.relation_id,
+						 NEW.id,
+						 NEW.storage,
+						 NULL,
+						 NEW.min_value,
+						 NEW.max_value);
+
+			RETURN NEW;
+		END
+		$aais$ LANGUAGE plpgsql;
+
+		CREATE FUNCTION adapt_and_insert_shard_placement() RETURNS trigger AS $aaisp$
+		BEGIN
+			INSERT INTO pg_dist_shard_placement
+						(shardid,
+						 shardstate,
+						 shardlength,
+						 nodename,
+						 nodeport)
+			VALUES      (NEW.shard_id,
+						 NEW.shard_state,
+						 0,
+						 NEW.node_name,
+						 NEW.node_port)
+			RETURNING oid INTO STRICT NEW.id;
+
+			RETURN NEW;
+		END
+		$aaisp$ LANGUAGE plpgsql;
+
+		CREATE FUNCTION adapt_and_insert_partition() RETURNS trigger AS $aaip$
+		BEGIN
+			INSERT INTO pg_dist_partition
+						(logicalrelid,
+						 partmethod,
+						 partkey)
+			VALUES      (NEW.relation_id,
+						 NEW.partition_method,
+						 column_name_to_column(NEW.relation_id, NEW.key));
+
+			RETURN NEW;
+		END
+		$aaip$ LANGUAGE plpgsql;
+
+		-- metadata relations are views under CitusDB
+		CREATE VIEW pgs_distribution_metadata.shard AS
+			SELECT shardid       AS id,
+				   logicalrelid  AS relation_id,
+				   shardstorage  AS storage,
+				   shardminvalue AS min_value,
+				   shardmaxvalue AS max_value
+			FROM   pg_dist_shard;
+
+		CREATE TRIGGER shard_insert
+		INSTEAD OF INSERT ON pgs_distribution_metadata.shard
+			FOR EACH ROW
+			EXECUTE PROCEDURE adapt_and_insert_shard();
+
+		CREATE VIEW pgs_distribution_metadata.shard_placement AS
+			SELECT oid::bigint AS id,
+				   shardid     AS shard_id,
+				   shardstate  AS shard_state,
+				   nodename    AS node_name,
+				   nodeport    AS node_port
+			FROM   pg_dist_shard_placement;
+
+		CREATE TRIGGER shard_placement_insert
+		INSTEAD OF INSERT ON pgs_distribution_metadata.shard_placement
+			FOR EACH ROW
+			EXECUTE PROCEDURE adapt_and_insert_shard_placement();
+
+		CREATE VIEW pgs_distribution_metadata.partition AS
+			SELECT logicalrelid AS relation_id,
+				   partmethod   AS partition_method,
+				   column_to_column_name(logicalrelid, partkey) AS key
+			FROM   pg_dist_partition;
+
+		CREATE TRIGGER partition_insert
+		INSTEAD OF INSERT ON pgs_distribution_metadata.partition
+			FOR EACH ROW
+			EXECUTE PROCEDURE adapt_and_insert_partition();
+	ELSE
+		-- add default values to id columns
+		ALTER TABLE pgs_distribution_metadata.shard
+			ALTER COLUMN id
+			SET DEFAULT nextval('pgs_distribution_metadata.shard_id_sequence');
+		ALTER TABLE pgs_distribution_metadata.shard_placement
+			ALTER COLUMN id
+			SET DEFAULT nextval('pgs_distribution_metadata.shard_placement_id_sequence');
+
+		-- associate sequences with their columns
+		ALTER SEQUENCE pgs_distribution_metadata.shard_id_sequence
+			OWNED BY pgs_distribution_metadata.shard.id;
+		ALTER SEQUENCE pgs_distribution_metadata.shard_placement_id_sequence
+			OWNED BY pgs_distribution_metadata.shard_placement.id;
+	END IF;
+END;
+$$;
+
+-- Syncs rows from the pg_shard distribution metadata related to the specified
+-- table name into the metadata tables used by CitusDB. After a call to this
+-- function for a particular pg_shard table, that table will become usable for
+-- queries within CitusDB. If placement health has changed for given pg_shard
+-- table, calling this function an additional time will propagate those health
+-- changes to the CitusDB metadata tables.
+CREATE OR REPLACE FUNCTION sync_table_metadata_to_citus(table_name text)
+RETURNS void
+AS $sync_table_metadata_to_citus$
+	DECLARE
+		table_relation_id CONSTANT oid NOT NULL := table_name::regclass::oid;
+		dummy_shard_length CONSTANT bigint := 0;
+		warning_msg CONSTANT text := 'sync_table_metadata_to_citus is deprecated and ' ||
+									 'will be removed in a future version';
+	BEGIN
+		RAISE WARNING '%', warning_msg;
+
+		-- grab lock to ensure single writer for upsert
+		LOCK TABLE pg_dist_shard_placement IN EXCLUSIVE MODE;
+
+		-- First, update the health of shard placement rows already copied
+		-- from pg_shard to CitusDB. Health is the only mutable attribute,
+		-- so it is presently the only one needing the UPDATE treatment.
+		UPDATE pg_dist_shard_placement
+		SET    shardstate = shard_placement.shard_state
+		FROM   pgs_distribution_metadata.shard_placement
+		WHERE  shardid = shard_placement.shard_id AND
+			   nodename = shard_placement.node_name AND
+			   nodeport = shard_placement.node_port AND
+			   shardid IN (SELECT shardid
+						   FROM   pg_dist_shard
+						   WHERE  logicalrelid = table_relation_id);
+
+		-- copy pg_shard placement rows not yet in CitusDB's metadata tables
+		INSERT INTO pg_dist_shard_placement
+					(shardid,
+					 shardstate,
+					 shardlength,
+					 nodename,
+					 nodeport)
+		SELECT shard_id,
+			   shard_state,
+			   dummy_shard_length,
+			   node_name,
+			   node_port
+		FROM   pgs_distribution_metadata.shard_placement
+			   LEFT OUTER JOIN pg_dist_shard_placement
+							ON ( shardid = shard_placement.shard_id AND
+								 nodename = shard_placement.node_name AND
+								 nodeport = shard_placement.node_port )
+		WHERE  shardid IS NULL AND
+			   shard_id IN (SELECT id
+							FROM   pgs_distribution_metadata.shard
+							WHERE  relation_id = table_relation_id);
+
+		-- copy pg_shard shard rows not yet in CitusDB's metadata tables
+		INSERT INTO pg_dist_shard
+					(shardid,
+					 logicalrelid,
+					 shardstorage,
+					 shardminvalue,
+					 shardmaxvalue)
+		SELECT id,
+			   relation_id,
+			   storage,
+			   min_value,
+			   max_value
+		FROM   pgs_distribution_metadata.shard
+			   LEFT OUTER JOIN pg_dist_shard
+							ON ( shardid = shard.id )
+		WHERE  shardid IS NULL AND
+			   relation_id = table_relation_id;
+
+		-- Finally, copy pg_shard partition rows not yet in CitusDB's metadata
+		-- tables. CitusDB uses a textual form of a Var node representing the
+		-- partition column, so we must use a special function to transform the
+		-- representation used by pg_shard (which is just the column name).
+		INSERT INTO pg_dist_partition
+					(logicalrelid,
+					 partmethod,
+					 partkey)
+		SELECT relation_id,
+			   partition_method,
+			   partition_column_to_node_string(table_relation_id)
+		FROM   pgs_distribution_metadata.partition
+			   LEFT OUTER JOIN pg_dist_partition
+							ON ( logicalrelid = partition.relation_id )
+		WHERE  logicalrelid IS NULL AND
+			   relation_id = table_relation_id;
+	END;
+$sync_table_metadata_to_citus$ LANGUAGE 'plpgsql';
+
+COMMENT ON FUNCTION sync_table_metadata_to_citus(text)
+		IS 'synchronize a distributed table''s pg_shard metadata to CitusDB';

--- a/pg_shard--1.2.sql
+++ b/pg_shard--1.2.sql
@@ -73,7 +73,7 @@ BEGIN
 						 partkey)
 			VALUES      (NEW.relation_id,
 						 NEW.partition_method,
-						 column_name_to_column(NEW.relation_id, NEW.key));
+						 column_name_to_column(NEW.relation_id::oid, NEW.key));
 
 			RETURN NEW;
 		END

--- a/pg_shard--1.2.sql
+++ b/pg_shard--1.2.sql
@@ -89,6 +89,16 @@ RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE FUNCTION column_name_to_column(table_oid oid, column_name text)
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE STRICT;
+
+CREATE FUNCTION column_to_column_name(table_oid oid, column_var text)
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE STRICT;
+
 COMMENT ON FUNCTION partition_column_to_node_string(oid)
 		IS 'return textual form of distributed table''s partition column';
 

--- a/pg_shard--1.2.sql
+++ b/pg_shard--1.2.sql
@@ -11,14 +11,13 @@ LANGUAGE C STABLE STRICT;
 
 DO $$
 DECLARE
-	replication_factor integer;
 	use_citus_metadata boolean := false;
 BEGIN
 	BEGIN
-		replication_factor = current_setting('shard_replication_factor')::integer;
-		use_citus_metadata = (replication_factor IS NOT NULL);
+		PERFORM 'pg_catalog.pg_dist_partition'::regclass;
+		use_citus_metadata = true;
 	EXCEPTION
-		WHEN undefined_object THEN
+		WHEN undefined_table THEN
 			use_citus_metadata = false;
 	END;
 

--- a/pg_shard--1.2.sql
+++ b/pg_shard--1.2.sql
@@ -224,7 +224,11 @@ AS $sync_table_metadata_to_citus$
 	DECLARE
 		table_relation_id CONSTANT oid NOT NULL := table_name::regclass::oid;
 		dummy_shard_length CONSTANT bigint := 0;
+		warning_msg CONSTANT text := 'sync_table_metadata_to_citus is deprecated and ' ||
+									 'will be removed in a future version';
 	BEGIN
+		RAISE WARNING '%', warning_msg;
+
 		-- grab lock to ensure single writer for upsert
 		LOCK TABLE pg_dist_shard_placement IN EXCLUSIVE MODE;
 

--- a/pg_shard--1.2.sql
+++ b/pg_shard--1.2.sql
@@ -73,7 +73,7 @@ BEGIN
 						 partkey)
 			VALUES      (NEW.relation_id,
 						 NEW.partition_method,
-						 column_name_to_column(NEW.relation_id::oid, NEW.key));
+						 column_name_to_column(NEW.relation_id, NEW.key));
 
 			RETURN NEW;
 		END

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -664,7 +664,7 @@ ExtractFirstDistributedTableId(Query *query)
 	{
 		RangeTblEntry *rangeTableEntry = (RangeTblEntry *) lfirst(rangeTableCell);
 
-		if (rangeTableEntry->rtekind == RTE_RELATION && IsDistributedTable(rangeTableEntry->relid))
+		if (IsDistributedTable(rangeTableEntry->relid))
 		{
 			distributedTableId = rangeTableEntry->relid;
 			break;

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -664,7 +664,7 @@ ExtractFirstDistributedTableId(Query *query)
 	{
 		RangeTblEntry *rangeTableEntry = (RangeTblEntry *) lfirst(rangeTableCell);
 
-		if (IsDistributedTable(rangeTableEntry->relid))
+		if (rangeTableEntry->rtekind == RTE_RELATION && IsDistributedTable(rangeTableEntry->relid))
 		{
 			distributedTableId = rangeTableEntry->relid;
 			break;

--- a/prune_shard_list.h
+++ b/prune_shard_list.h
@@ -20,9 +20,6 @@
 #include "nodes/primnodes.h"
 
 
-/* character used to indicate a hash-partitioned table */
-#define DISTRIBUTE_BY_HASH 'h'
-
 /*
  * Column ID used to signify that a partition column value has been replaced by
  * its hashed value.

--- a/sql/citus_metadata_sync.sql
+++ b/sql/citus_metadata_sync.sql
@@ -36,6 +36,25 @@ SELECT partition_column_to_node_string('pg_class'::regclass);
 -- should get node representation for distributed table
 SELECT partition_column_to_node_string('set_of_ids'::regclass);
 
+-- should get error for system or non-existent column
+SELECT column_name_to_column('set_of_ids'::regclass, 'ctid');
+SELECT column_name_to_column('set_of_ids'::regclass, 'non_existent');
+
+-- should get node representation for valid column
+SELECT column_name_to_column('set_of_ids'::regclass, 'id') AS column_var
+\gset
+
+SELECT replace(:'column_var', ':varattno 1', ':varattno -1') AS ctid_var,
+	   replace(:'column_var', ':varattno 1', ':varattno 2') AS non_ext_var
+\gset
+
+-- should get error for system or non-existent column
+SELECT column_to_column_name('set_of_ids'::regclass, :'ctid_var');
+SELECT column_to_column_name('set_of_ids'::regclass, :'non_ext_var');
+
+-- should get node representation for valid column
+SELECT column_to_column_name('set_of_ids'::regclass, :'column_var');
+
 -- create subset of CitusDB metadata schema
 CREATE TABLE pg_dist_partition (
 	logicalrelid oid NOT NULL,

--- a/sql/citus_metadata_sync.sql
+++ b/sql/citus_metadata_sync.sql
@@ -36,6 +36,9 @@ SELECT partition_column_to_node_string('pg_class'::regclass);
 -- should get node representation for distributed table
 SELECT partition_column_to_node_string('set_of_ids'::regclass);
 
+-- should get error for column names that are too long
+SELECT column_name_to_column('set_of_ids'::regclass, repeat('a', 1024));
+
 -- should get error for system or non-existent column
 SELECT column_name_to_column('set_of_ids'::regclass, 'ctid');
 SELECT column_name_to_column('set_of_ids'::regclass, 'non_existent');
@@ -118,7 +121,7 @@ ORDER BY nodename;
 -- mark a placement as unhealthy and add a new one
 UPDATE pgs_distribution_metadata.shard_placement
 SET    shard_state = :inactive
-WHERE  id = 102;
+WHERE  node_name = 'cluster-worker-02';
 
 INSERT INTO pgs_distribution_metadata.shard_placement
 	(id, node_name, node_port, shard_id, shard_state)

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -12,3 +12,17 @@ LANGUAGE C STRICT;
 
 CREATE FOREIGN DATA WRAPPER fake_fdw HANDLER fake_fdw_handler;
 CREATE SERVER fake_fdw_server FOREIGN DATA WRAPPER fake_fdw;
+
+-- Set pg_shard sequence to start at same number as that used by CitusDB.
+-- This makes testing easier, since shard IDs will match.
+DO $$
+BEGIN
+	BEGIN
+		PERFORM setval('pgs_distribution_metadata.shard_id_sequence',
+					   102008, false);
+	EXCEPTION
+	WHEN undefined_table THEN
+		-- do nothing
+	END;
+END;
+$$;

--- a/sql/modifications.sql
+++ b/sql/modifications.sql
@@ -149,8 +149,11 @@ WITH limit_order_placements AS (
 		AND    s.relation_id = 'limit_orders'::regclass
 	)
 INSERT INTO pgs_distribution_metadata.shard_placement
-SELECT nextval('pgs_distribution_metadata.shard_placement_id_sequence'),
-	   shard_id,
+			(shard_id,
+			 shard_state,
+			 node_name,
+			 node_port)
+SELECT shard_id,
 	   shard_state,
 	   'badhost',
 	   54321

--- a/test/distribution_metadata.c
+++ b/test/distribution_metadata.c
@@ -21,7 +21,10 @@
 #include <stdint.h>
 
 #include "catalog/pg_type.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "executor/spi.h"
+#pragma GCC diagnostic pop
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"

--- a/test/distribution_metadata.c
+++ b/test/distribution_metadata.c
@@ -21,15 +21,14 @@
 #include <stdint.h>
 
 #include "catalog/pg_type.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "executor/spi.h"
-#pragma GCC diagnostic pop
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 #include "storage/lock.h"
 #include "utils/array.h"
+#include "utils/elog.h"
+#include "utils/errcodes.h"
 #include "utils/builtins.h"
 #include "utils/palloc.h"
 

--- a/test/distribution_metadata.c
+++ b/test/distribution_metadata.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "catalog/pg_type.h"
+#include "executor/spi.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
@@ -307,10 +308,28 @@ Datum
 delete_shard_placement_row(PG_FUNCTION_ARGS)
 {
 	int64 shardPlacementId = PG_GETARG_INT64(0);
+	bool successful = false;
 
-	DeleteShardPlacementRow(shardPlacementId);
+	PG_TRY();
+	{
+		DeleteShardPlacementRow(shardPlacementId);
+		successful = true;
+	}
+	PG_CATCH();
+	{
+		if (geterrcode() == ERRCODE_UNDEFINED_OBJECT)
+		{
+			SPI_finish();
+			FlushErrorState();
+		}
+		else
+		{
+			PG_RE_THROW();
+		}
+	}
+	PG_END_TRY();
 
-	PG_RETURN_VOID();
+	PG_RETURN_BOOL(successful);
 }
 
 
@@ -323,10 +342,28 @@ update_shard_placement_row_state(PG_FUNCTION_ARGS)
 {
 	int64 shardPlacementId = PG_GETARG_INT64(0);
 	ShardState shardState = (ShardState) PG_GETARG_INT32(1);
+	bool successful = false;
 
-	UpdateShardPlacementRowState(shardPlacementId, shardState);
+	PG_TRY();
+	{
+		UpdateShardPlacementRowState(shardPlacementId, shardState);
+		successful = true;
+	}
+	PG_CATCH();
+	{
+		if (geterrcode() == ERRCODE_UNDEFINED_OBJECT)
+		{
+			SPI_finish();
+			FlushErrorState();
+		}
+		else
+		{
+			PG_RE_THROW();
+		}
+	}
+	PG_END_TRY();
 
-	PG_RETURN_VOID();
+	PG_RETURN_BOOL(successful);
 }
 
 


### PR DESCRIPTION
OK, so this has been entirely rebased on top of the changes from #110, i.e. we're using SPI everywhere now. This review is now all about the triggers and views needed to adapt CitusDB's metadata tables to be used within `pg_shard`.

Travis is building this under PostgreSQL 9.3/9.4, and CitusDB 4.0, so there is some assurance this actually works.

**Code Review Tasks**

  - [x] Add initialization mode to assign variables based on CitusDB presence
  - [x] Figure out how to test this
  - [x] Transform `pg_shard` tables into views when Citus present (to prevent them from appearing blank), or just error out when queried.
  - [x] Determine ramifications for upgrading from `pg_shard` to CitusDB. Users might `pg_dump` from a PostgreSQL `pg_shard` install and try to load into CitusDB. This must work seamlessly.
  - [x] Determine interoperability requirements for `\STAGE` and using an existing CitusDB-distributed table with `pg_shard`
  - [x] Address interoperability issues

Resolves #11.
Resolves #27.
