### PR TITLE
Check column name length in ColumnNameToColumn

### DIFF
--- a/create_shards.c
+++ b/create_shards.c
@@ -188,14 +188,14 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	if (shardCount <= 0)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						errmsg("shardCount must be positive")));
+						errmsg("shard_count must be positive")));
 	}
 
 	/* make sure that at least one replica is specified */
 	if (replicationFactor <= 0)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						errmsg("replicationFactor must be positive")));
+						errmsg("replication_factor must be positive")));
 	}
 
 	/* calculate the split of the hash space */
@@ -215,7 +215,7 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	if (replicationFactor > workerNodeCount)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						errmsg("replicationFactor (%d) exceeds number of worker nodes "
+						errmsg("replication_factor (%d) exceeds number of worker nodes "
 							   "(%d)", replicationFactor, workerNodeCount),
 						errhint("Add more worker nodes or try again with a lower "
 								"replication factor.")));

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -455,11 +455,9 @@ ColumnNameToColumn(Oid relationId, char *columnName)
 	/* check length to prevent failed Assert for long names in get_attnum */
 	if (strnlen(columnName, NAMEDATALEN) == NAMEDATALEN)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_NAME_TOO_LONG),
-				 errmsg("columnName too long"),
-				 errdetail("columnName must be less than %d characters.",
-						   NAMEDATALEN)));
+		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("columnName too long"),
+						errdetail("columnName must be less than %d characters.",
+								  NAMEDATALEN)));
 	}
 
 	columnId = get_attnum(relationId, columnName);

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -455,8 +455,8 @@ ColumnNameToColumn(Oid relationId, char *columnName)
 	/* check length to prevent failed Assert for long names in get_attnum */
 	if (strnlen(columnName, NAMEDATALEN) == NAMEDATALEN)
 	{
-		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("columnName too long"),
-						errdetail("columnName must be less than %d characters.",
+		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("column name too long"),
+						errdetail("Column name must be less than %d characters.",
 								  NAMEDATALEN)));
 	}
 

--- a/expected/create_shards.out
+++ b/expected/create_shards.out
@@ -79,13 +79,13 @@ SELECT partition_method, key FROM pgs_distribution_metadata.partition
 
 -- use a bad shard count
 SELECT master_create_worker_shards('table_to_distribute', 0, 1);
-ERROR:  shardCount must be positive
+ERROR:  shard_count must be positive
 -- use a bad replication factor
 SELECT master_create_worker_shards('table_to_distribute', 16, 0);
-ERROR:  replicationFactor must be positive
+ERROR:  replication_factor must be positive
 -- use a replication factor higher than shard count
 SELECT master_create_worker_shards('table_to_distribute', 16, 3);
-ERROR:  replicationFactor (3) exceeds number of worker nodes (2)
+ERROR:  replication_factor (3) exceeds number of worker nodes (2)
 HINT:  Add more worker nodes or try again with a lower replication factor.
 \set VERBOSITY terse
 -- use a replication factor higher than healthy node count

--- a/expected/distribution_metadata.out
+++ b/expected/distribution_metadata.out
@@ -170,8 +170,8 @@ BEGIN;
 	WHERE  relation_id = 'events' :: regclass;
 	---- should see error that partition column is too long
 	SELECT Partition_column_id('events');
-ERROR:  columnName too long
-DETAIL:  columnName must be less than 64 characters.
+ERROR:  column name too long
+DETAIL:  Column name must be less than 64 characters.
 ROLLBACK;
 -- should see error (catalog is not distributed)
 SELECT partition_column_id('pg_type');

--- a/expected/distribution_metadata.out
+++ b/expected/distribution_metadata.out
@@ -164,6 +164,15 @@ SELECT partition_column_id('events');
                    2
 (1 row)
 
+BEGIN;
+	UPDATE pgs_distribution_metadata.partition
+	SET    key = REPEAT('a', 1024)
+	WHERE  relation_id = 'events' :: regclass;
+	---- should see error that partition column is too long
+	SELECT Partition_column_id('events');
+ERROR:  columnName too long
+DETAIL:  columnName must be less than 64 characters.
+ROLLBACK;
 -- should see error (catalog is not distributed)
 SELECT partition_column_id('pg_type');
 ERROR:  no partition column is defined for relation "pg_type"

--- a/sql/distribution_metadata.sql
+++ b/sql/distribution_metadata.sql
@@ -150,6 +150,15 @@ SELECT load_shard_placement_array(6, false);
 -- should see column id of 'name'
 SELECT partition_column_id('events');
 
+BEGIN;
+	UPDATE pgs_distribution_metadata.partition
+	SET    key = REPEAT('a', 1024)
+	WHERE  relation_id = 'events' :: regclass;
+
+	---- should see error that partition column is too long
+	SELECT Partition_column_id('events');
+ROLLBACK;
+
 -- should see error (catalog is not distributed)
 SELECT partition_column_id('pg_type');
 


### PR DESCRIPTION
Discovered that system cache lookups have Asserts that fail if any name over `NAMEDATALEN` is provided. This change gives a nicer behavior than just crashing the whole backend.

I also discovered that `ResolveRelationId` silently truncates its input, which I initially thought I'd fix. It appears _many_ functions that use the [`name` data type](http://www.postgresql.org/docs/9.4/static/datatype-character.html#DATATYPE-CHARACTER-SPECIAL-TABLE) also silently truncate their input, so I left that as-is. At any rate, it accepts a qualified name (delimited by periods), so detecting whether any given part of that is too long is more trouble than it's worth, especially when other pieces of PostgreSQL proper truncate regardless.