### PR TITLE
Reject unknown partition types

### DIFF
--- a/create_shards.c
+++ b/create_shards.c
@@ -130,6 +130,12 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 							   "defined to use range partitioning.")));
 		}
 	}
+	else
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("unrecognized table partition type: %c",
+							   partitionMethod)));
+	}
 
 	/* insert row into the partition metadata table */
 	InsertPartitionRow(distributedTableId, partitionMethod, partitionColumnText);

--- a/expected/create_shards.out.tmpl
+++ b/expected/create_shards.out.tmpl
@@ -52,6 +52,9 @@ ERROR:  column "bad_column" of relation "table_to_distribute" does not exist
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 ERROR:  pg_shard only supports hash partitioning
+-- use unrecognized partition type
+SELECT master_create_distributed_table('table_to_distribute', 'name', 'z');
+ERROR:  unrecognized table partition type: z
 -- use a partition column of a type lacking any default operator class
 SELECT master_create_distributed_table('table_to_distribute', 'json_data');
 ERROR:  data type json has no default operator class for specified partition method

--- a/sql/create_shards.sql.tmpl
+++ b/sql/create_shards.sql.tmpl
@@ -61,6 +61,9 @@ SELECT master_create_distributed_table('table_to_distribute', 'bad_column');
 -- use unsupported partition type
 SELECT master_create_distributed_table('table_to_distribute', 'name', 'r');
 
+-- use unrecognized partition type
+SELECT master_create_distributed_table('table_to_distribute', 'name', 'z');
+
 -- use a partition column of a type lacking any default operator class
 SELECT master_create_distributed_table('table_to_distribute', 'json_data');
 


### PR DESCRIPTION
Surprising that this conditional didn't already have an else clause, but so it goes. This causes us to reject any partition types we don't explicitly support (the function used to silently succeed).