### PR TITLE
Throw error for zero-shard INSERTs

### DIFF
--- a/expected/modifications.out
+++ b/expected/modifications.out
@@ -10,7 +10,14 @@ CREATE TABLE limit_orders (
 	kind order_side NOT NULL,
 	limit_price decimal NOT NULL DEFAULT 0.00 CHECK (limit_price >= 0.00)
 );
+CREATE TABLE insufficient_shards ( LIKE limit_orders );
 SELECT master_create_distributed_table('limit_orders', 'id');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_distributed_table('insufficient_shards', 'id');
  master_create_distributed_table 
 ---------------------------------
  
@@ -25,6 +32,17 @@ WARNING:  could not create shard on "adeadhost:5432"
  
 (1 row)
 
+-- make a single shard that covers no partition values
+SELECT master_create_worker_shards('insufficient_shards', 1, 1);
+WARNING:  Connection failed to adeadhost:5432
+WARNING:  could not create shard on "adeadhost:5432"
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+UPDATE pgs_distribution_metadata.shard SET min_value = 0, max_value = 0
+WHERE relation_id = 'insufficient_shards'::regclass;
 \set VERBOSITY default
 -- basic single-row INSERT
 INSERT INTO limit_orders VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
@@ -35,6 +53,11 @@ SELECT COUNT(*) FROM limit_orders WHERE id = 32743;
      1
 (1 row)
 
+-- try a single-row INSERT with no shard to receive it
+INSERT INTO insufficient_shards VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
+										20.69);
+ERROR:  could not find destination shard for new row
+DETAIL:  Target relation does not contain any shards capable of storing the new row.
 -- INSERT with DEFAULT in the target list
 INSERT INTO limit_orders VALUES (12756, 'MSFT', 10959, '2013-05-08 07:29:23', 'sell',
 								 DEFAULT);

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -254,8 +254,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10036 WHERE (word_count > 10000)
 LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10038 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -254,8 +254,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10036 WHERE (word_count > 10000)
 LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10038 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -1121,9 +1121,17 @@ PgShardExecutorStart(QueryDesc *queryDesc, int eflags)
 
 		if (zeroShardQuery)
 		{
-			/* if zero shards are involved, let query hit local table */
+			/* if zero shards are involved, let non-INSERTs hit local table */
 			Plan *originalPlan = distributedPlan->originalPlan;
 			plannedStatement->planTree = originalPlan;
+
+			if (plannedStatement->commandType == CMD_INSERT)
+			{
+				ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+								errmsg("could not find destination shard for new row"),
+								errdetail("Target relation does not contain any shards "
+										  "capable of storing the new row.")));
+			}
 
 			NextExecutorStartHook(queryDesc, eflags);
 		}

--- a/sql/modifications.sql
+++ b/sql/modifications.sql
@@ -13,16 +13,28 @@ CREATE TABLE limit_orders (
 	limit_price decimal NOT NULL DEFAULT 0.00 CHECK (limit_price >= 0.00)
 );
 
+CREATE TABLE insufficient_shards ( LIKE limit_orders );
+
 SELECT master_create_distributed_table('limit_orders', 'id');
+SELECT master_create_distributed_table('insufficient_shards', 'id');
 
 \set VERBOSITY terse
 SELECT master_create_worker_shards('limit_orders', 2, 1);
+
+-- make a single shard that covers no partition values
+SELECT master_create_worker_shards('insufficient_shards', 1, 1);
+UPDATE pgs_distribution_metadata.shard SET min_value = 0, max_value = 0
+WHERE relation_id = 'insufficient_shards'::regclass;
 \set VERBOSITY default
 
 -- basic single-row INSERT
 INSERT INTO limit_orders VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
 								 20.69);
 SELECT COUNT(*) FROM limit_orders WHERE id = 32743;
+
+-- try a single-row INSERT with no shard to receive it
+INSERT INTO insufficient_shards VALUES (32743, 'AAPL', 9580, '2004-10-19 10:23:54', 'buy',
+										20.69);
 
 -- INSERT with DEFAULT in the target list
 INSERT INTO limit_orders VALUES (12756, 'MSFT', 10959, '2013-05-08 07:29:23', 'sell',


### PR DESCRIPTION
Found this when doing CitusDB integration. If CitusDB has created an e.g. range partition table I found it "just works" with pg_shard save one caveat: if no shard exists to receive an incoming row, our zero-shard SELECT logic kicked in and pg_shard would happily put the row into the local relation.

UPDATE and DELETE are safe to run locally as the local table should be empty to begin with, but INSERT is not: we should raise an error rather than continue with a zero-shard INSERT.