### PR TITLE
Conditionally support functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS = connection.o create_shards.o citus_metadata_sync.o distribution_metadata.
 	   extend_ddl_commands.o generate_ddl_commands.o pg_shard.o prune_shard_list.o \
 	   repair_shards.o ruleutils.o
 
-PG_CPPFLAGS = -std=c99 -Wall -Wextra -I$(libpq_srcdir)
+PG_CPPFLAGS = -std=c99 -Wall -Wextra -I$(libpq_srcdir) -DEXP_SUPPORT_EXPRS
 
 # pg_shard and CitusDB have several functions that share the same name. When we
 # link pg_shard against CitusDB on Linux, the loader resolves to the CitusDB

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ifeq ($(enable_coverage),yes)
 	EXTRA_CLEAN += *.gcno *.gcda test/*.gcno test/*.gcda
 endif
 
-ifneq ($(SUPPORT_SHARD_EXPRS), undefined)
+ifeq ($(SUPPORT_SHARD_EXPRS), yes)
     PG_CPPFLAGS += -DSUPPORT_SHARD_EXPRS
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS = connection.o create_shards.o citus_metadata_sync.o distribution_metadata.
 	   extend_ddl_commands.o generate_ddl_commands.o pg_shard.o prune_shard_list.o \
 	   repair_shards.o ruleutils.o
 
-PG_CPPFLAGS = -std=c99 -Wall -Wextra -I$(libpq_srcdir) -DEXP_SUPPORT_EXPRS
+PG_CPPFLAGS = -std=c99 -Wall -Wextra -I$(libpq_srcdir)
 
 # pg_shard and CitusDB have several functions that share the same name. When we
 # link pg_shard against CitusDB on Linux, the loader resolves to the CitusDB
@@ -56,6 +56,11 @@ ifeq ($(enable_coverage),yes)
 	PG_CPPFLAGS += --coverage
 	SHLIB_LINK  += --coverage
 	EXTRA_CLEAN += *.gcno *.gcda test/*.gcno test/*.gcda
+endif
+
+ifneq ($(SUPPORT_SHARD_EXPRS), undefined)
+    PG_CPPFLAGS += -DSUPPORT_SHARD_EXPRS
+
 endif
 
 # Let the test makefile tell us what objects to build.

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -547,12 +547,14 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		}
 	}
 
+    #ifndef $(experimentalSupportExprs)
 	if (hasNonConstTargetEntryExprs || hasNonConstQualExprs)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot plan sharded modification containing values "
 							   "which are not constants or constant expressions")));
 	}
+    #endif
 
 	if (specifiesPartitionValue && (commandType == CMD_UPDATE))
 	{

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -547,7 +547,7 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		}
 	}
 
-    #ifndef $(experimentalSupportExprs)
+    #ifndef EXP_SUPPORT_EXPRS
 	if (hasNonConstTargetEntryExprs || hasNonConstQualExprs)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -88,6 +88,14 @@ bool UseCitusDBSelectLogic = false;
 /* logs each statement used in a distributed plan */
 bool LogDistributedStatements = false;
 
+/* EXPERIMENTAL: Allow support of expressions in setting values on shards. */
+
+#ifndef SUPPORT_SHARD_EXPRS
+bool SupportShardExprs = false;
+#else 
+bool SupportShardExprs = true;
+#endif
+
 
 /* planner functions forward declarations */
 static PlannedStmt * PgShardPlanner(Query *parse, int cursorOptions,
@@ -547,14 +555,15 @@ ErrorIfQueryNotSupported(Query *queryTree)
 		}
 	}
 
-    #ifndef EXP_SUPPORT_EXPRS
-	if (hasNonConstTargetEntryExprs || hasNonConstQualExprs)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot plan sharded modification containing values "
-							   "which are not constants or constant expressions")));
-	}
-    #endif
+    if (!SupportShardExprs)
+    {
+        if (hasNonConstTargetEntryExprs || hasNonConstQualExprs)
+        {
+            ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                            errmsg("cannot plan sharded modification containing values "
+                                   "which are not constants or constant expressions")));
+        }
+    }
 
 	if (specifiesPartitionValue && (commandType == CMD_UPDATE))
 	{


### PR DESCRIPTION
Addresses issue #108. 

Mostly submitting to show that my idle curiosity is satisfied. Naturally, allowing function calls to go through to the shard workers includes a lot of unknowns, particularly around which extensions are loaded, which stored procedures have been saved, probably other things that I don't know about off the top of my head. I'm not sure what the best way to handle that would be, but maybe allowing a whitelist of function names that the maintainer of a cluster knows is on each of the postgres workers would be a good start? For now, this patch satisfies my use-case.

- Tested on Postgres 9.4 on Ubuntu 15.04, and Ubuntu 14.04.
- Supplying an environment variable during compile time ``SUPPORT_SHARD_EXPRS`` set to 'yes' will result in the preprocessor to remove the checks for expressions being passed to shard workers from the query tree.

Example Table Definition:

```sql
template1=# \d test
     Table "public.test"
 Column |  Type   | Modifiers 
--------+---------+-----------
 id     | integer | 
 date   | date    | 
```

Example before patch:

```sql
template1=# insert into test values(111223232, now()::date);
ERROR:  cannot plan sharded modification containing values which are not constants or constant expressions
```
Example after patch:

```sql
template1=# insert into test values(111223233, now()::date);
INSERT 0 1
```