### PR TITLE
Push simple aggregates down 

### DIFF
--- a/expected/queries.out
+++ b/expected/queries.out
@@ -365,19 +365,19 @@ LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY article
 
 		
 -- a query with WHERE, function call with const value and GROUP BY on partition column
-SELECT author_id, double_single_int(author_id::int + 15) FROM articles
+SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id, author_id AS double_single_int, author_id AS double_single_int FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
-LOG:  distributed statement: SELECT author_id, author_id AS double_single_int, author_id AS double_single_int FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
  author_id | double_single_int 
 -----------+-------------------
-        10 |               625
-         9 |               576
-         8 |               529
-         7 |               484
-         6 |               441
+        10 |               225
+         9 |               225
+         8 |               225
+         7 |               225
+         6 |               225
 (5 rows)
 
 		

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -307,25 +307,26 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
         10
 (10 rows)
 
--- a query with GROUP BY on partition column where ORDER BY column must be pulled
-SELECT count(*) FROM articles
-	GROUP BY author_id
-	ORDER BY author_id;
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
- count 
--------
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-(10 rows)
+-- a query with GROUP BY on partition column where ORDER BY column(s) must be pulled
+SELECT 
+	id, count(*) as cnt FROM articles
+WHERE
+	author_id  > 0
+GROUP BY 
+	author_id, id
+ORDER BY 
+	max(word_count), author_id  DESC 
+LIMIT 5;
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10036 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+ id | cnt 
+----+-----
+ 16 |   1
+  9 |   1
+ 45 |   1
+ 18 |   1
+ 11 |   1
+(5 rows)
 
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -307,6 +307,26 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
         10
 (10 rows)
 
+-- a query with GROUP BY on partition column where ORDER BY column must be pulled
+SELECT count(*) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ count 
+-------
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+(10 rows)
+
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -291,8 +291,8 @@ LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 W
 SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  author_id 
 -----------
          1
@@ -311,8 +311,8 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
 SELECT count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  count 
 -------
      5
@@ -331,8 +331,8 @@ LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY artic
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  author_id | count 
 -----------+-------
          1 |     5
@@ -369,6 +369,21 @@ LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FRO
         10 |  15
 (10 rows)
 
+-- a query with multiple HAVING clauses
+SELECT author_id, count(*) as cnt FROM articles
+	GROUP BY author_id
+	HAVING count(*) > 4 AND sum(author_id) > 30
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+ author_id | cnt 
+-----------+-----
+         7 |   5
+         8 |   5
+         9 |   5
+        10 |   5
+(4 rows)
+
 -- a query with WHERE, HAVING and GROUP BY on partition column
 SELECT author_id, count(*) as cnt FROM articles
 	WHERE author_id > 8
@@ -389,8 +404,8 @@ SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id HAVING true
  author_id | double_single_int 
 -----------+-------------------
         10 |               225
@@ -407,8 +422,8 @@ SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_val
 	GROUP BY author_id
 	ORDER BY sum_two_ints(7, author_id::int) DESC
 	LIMIT 3;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id HAVING true
  author_id | cnt | summed_value 
 -----------+-----+--------------
          8 |   5 |           15
@@ -422,8 +437,8 @@ SELECT author_id, word_count, count(*) as cnt FROM articles
 	WHERE author_id > 8 AND word_count > 8000
 	GROUP BY author_id, word_count
 	ORDER BY word_count DESC;	
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
  author_id | word_count | cnt 
 -----------+------------+-----
         10 |      19519 |   1

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -221,21 +221,6 @@ SELECT COUNT(*) FROM articles;
     50
 (1 row)
 
--- try query with more SQL features
-SELECT author_id, sum(word_count) AS corpus_size FROM articles
-	GROUP BY author_id
-	HAVING sum(word_count) > 25000
-	ORDER BY sum(word_count) DESC
-	LIMIT 5;
- author_id | corpus_size 
------------+-------------
-         4 |       66325
-         2 |       61782
-        10 |       59955
-         8 |       55410
-         6 |       50867
-(5 rows)
-
 -- cross-shard queries on a foreign table should fail
 -- we'll just point the article shards to a foreign table
 BEGIN;
@@ -261,22 +246,197 @@ LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE
     23
 (1 row)
 
-SET client_min_messages = DEFAULT;
-SET pg_shard.log_distributed_statements = DEFAULT;
--- use HAVING without its variable in target list
-SELECT author_id FROM articles
-	GROUP BY author_id
-	HAVING sum(word_count) > 50000
-	ORDER BY author_id;
- author_id 
------------
-         2
-         4
-         6
-         8
-        10
+-- function for tests
+CREATE OR REPLACE FUNCTION sum_two_ints(int,int) RETURNS int
+    AS $$ SELECT $1 + $2 $$
+    LANGUAGE SQL IMMUTABLE;
+-- function for tests
+CREATE OR REPLACE FUNCTION double_single_int(int) RETURNS int
+    AS $$ SELECT $1 * $1 $$
+    LANGUAGE SQL IMMUTABLE;
+-- use HAVING without its variable in target list when GROUP BY non-partition column
+SELECT title FROM articles
+	GROUP BY title
+	HAVING sum(word_count) > 18000
+	ORDER BY title;
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+   title    
+------------
+ alkylic
+ andesite
+ anjanette
+ archiblast
+ arsenous
 (5 rows)
 
+-- try query with more SQL features when GROUP BY non-partition column
+SELECT title, sum(word_count) AS corpus_size FROM articles
+	GROUP BY title
+	HAVING sum(word_count) > 2000
+	ORDER BY sum(word_count) DESC
+	LIMIT 5;
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+   title    | corpus_size 
+------------+-------------
+ anjanette  |       19519
+ andesite   |       19094
+ alkylic    |       18610
+ arsenous   |       18188
+ archiblast |       18185
+(5 rows)
+
+-- a simple query with GROUP BY on partition column
+SELECT author_id FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ author_id 
+-----------
+         1
+         2
+         3
+         4
+         5
+         6
+         7
+         8
+         9
+        10
+(10 rows)
+
+-- an aggregate query with GROUP BY on partition column
+SELECT author_id, count(*) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ author_id | count 
+-----------+-------
+         1 |     5
+         2 |     5
+         3 |     5
+         4 |     5
+         5 |     5
+         6 |     5
+         7 |     5
+         8 |     5
+         9 |     5
+        10 |     5
+(10 rows)
+
+-- a query with HAVING and GROUP BY on partition column
+-- project column includes an aggregate in an operator expression 
+SELECT author_id, (count(*) + author_id) as cnt FROM articles
+	GROUP BY author_id
+	HAVING (count(*) + author_id) > 4
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+ author_id | cnt 
+-----------+-----
+         1 |   6
+         2 |   7
+         3 |   8
+         4 |   9
+         5 |  10
+         6 |  11
+         7 |  12
+         8 |  13
+         9 |  14
+        10 |  15
+(10 rows)
+
+-- a query with WHERE, HAVING and GROUP BY on partition column
+SELECT author_id, count(*) as cnt FROM articles
+	WHERE author_id > 8
+	GROUP BY author_id
+	HAVING count(*) >= 5
+	ORDER BY author_id DESC;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+ author_id | cnt 
+-----------+-----
+        10 |   5
+         9 |   5
+(2 rows)
+
+		
+-- a query with WHERE, function call with const value and GROUP BY on partition column
+SELECT author_id, double_single_int(author_id::int + 15) FROM articles
+	WHERE author_id > 5
+	GROUP BY author_id
+	ORDER BY author_id DESC;
+LOG:  distributed statement: SELECT author_id, author_id AS double_single_int, author_id AS double_single_int FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, author_id AS double_single_int, author_id AS double_single_int FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
+ author_id | double_single_int 
+-----------+-------------------
+        10 |               625
+         9 |               576
+         8 |               529
+         7 |               484
+         6 |               441
+(5 rows)
+
+		
+-- a query with WHERE, LIMIT, HAVING, function call on data and GROUP BY on partition column
+SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_value FROM articles
+	WHERE author_id < 9
+	GROUP BY author_id
+	ORDER BY sum_two_ints(7, author_id::int) DESC
+	LIMIT 3;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id
+ author_id | cnt | summed_value 
+-----------+-----+--------------
+         8 |   5 |           15
+         7 |   5 |           14
+         6 |   5 |           13
+(3 rows)
+
+	
+-- a query with WHERE, HAVING, function call on data and GROUP BY on two columns including partition column
+SELECT author_id, word_count, count(*) as cnt FROM articles
+	WHERE author_id > 8 AND word_count > 8000
+	GROUP BY author_id, word_count
+	ORDER BY word_count DESC;	
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+ author_id | word_count | cnt 
+-----------+------------+-----
+        10 |      19519 |   1
+        10 |      17277 |   1
+        10 |      14976 |   1
+         9 |      10906 |   1
+         9 |       9524 |   1
+(5 rows)
+
+	
+-- GROUP BY on partition column where total number of projections are more than column count
+-- In this case, we do not push down GROUP BY
+SELECT author_id, count(*), sum(author_id), avg(author_id), max(author_id) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true
+ author_id | count | sum |          avg           | max 
+-----------+-------+-----+------------------------+-----
+         1 |     5 |   5 | 1.00000000000000000000 |   1
+         2 |     5 |  10 |     2.0000000000000000 |   2
+         3 |     5 |  15 |     3.0000000000000000 |   3
+         4 |     5 |  20 |     4.0000000000000000 |   4
+         5 |     5 |  25 |     5.0000000000000000 |   5
+         6 |     5 |  30 |     6.0000000000000000 |   6
+         7 |     5 |  35 |     7.0000000000000000 |   7
+         8 |     5 |  40 |     8.0000000000000000 |   8
+         9 |     5 |  45 |     9.0000000000000000 |   9
+        10 |     5 |  50 |    10.0000000000000000 |  10
+(10 rows)
+
+SET client_min_messages = DEFAULT;
+SET pg_shard.log_distributed_statements = DEFAULT;
 -- verify temp tables used by cross-shard queries do not persist
 SELECT COUNT(*) FROM pg_class WHERE relname LIKE 'pg_shard_temp_table%' AND
 									relkind = 'r';

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -308,24 +308,20 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE tru
 (10 rows)
 
 -- a query with GROUP BY on partition column where ORDER BY column(s) must be pulled
-SELECT 
-	id, count(*) as cnt FROM articles
-WHERE
-	author_id  > 0
-GROUP BY 
-	author_id, id
-ORDER BY 
-	max(word_count), author_id  DESC 
-LIMIT 5;
-LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
-LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10038 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
- id | cnt 
-----+-----
- 16 |   1
-  9 |   1
- 45 |   1
- 18 |   1
- 11 |   1
+SELECT  min(id), count(*) as cnt FROM articles
+	WHERE author_id  > 0
+	GROUP BY author_id
+	ORDER BY max(word_count), author_id  DESC 
+	LIMIT 5;
+LOG:  distributed statement: SELECT min(id) AS min, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT min(id) AS min, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10038 WHERE (author_id > 0) GROUP BY author_id HAVING true
+ min | cnt 
+-----+-----
+   9 |   5
+   5 |   5
+   1 |   5
+   7 |   5
+   3 |   5
 (5 rows)
 
 -- an aggregate query with GROUP BY on partition column
@@ -434,20 +430,20 @@ LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS sum
 
 	
 -- a query with WHERE, HAVING, function call on data and GROUP BY on two columns including partition column
-SELECT author_id, word_count, count(*) as cnt FROM articles
-	WHERE author_id > 8 AND word_count > 8000
-	GROUP BY author_id, word_count
-	ORDER BY word_count DESC;	
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10038 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
- author_id | word_count | cnt 
------------+------------+-----
-        10 |      19519 |   1
-        10 |      17277 |   1
-        10 |      14976 |   1
-         9 |      10906 |   1
-         9 |       9524 |   1
-(5 rows)
+SELECT author_id, sum(word_count), avg(word_count), count(*) as cnt FROM articles
+	WHERE author_id > 3
+	GROUP BY author_id
+	HAVING sum(word_count) > 8000 AND max(word_count) > 15000
+	ORDER BY sum(word_count) DESC;	
+LOG:  distributed statement: SELECT author_id, sum(word_count) AS sum, avg(word_count) AS avg, count(*) AS cnt FROM ONLY articles_10037 WHERE (author_id > 3) GROUP BY author_id HAVING ((sum(word_count) > 8000) AND (max(word_count) > 15000))
+LOG:  distributed statement: SELECT author_id, sum(word_count) AS sum, avg(word_count) AS avg, count(*) AS cnt FROM ONLY articles_10038 WHERE (author_id > 3) GROUP BY author_id HAVING ((sum(word_count) > 8000) AND (max(word_count) > 15000))
+ author_id |  sum  |          avg           | cnt 
+-----------+-------+------------------------+-----
+         4 | 66325 |     13265.000000000000 |   5
+        10 | 59955 | 11991.0000000000000000 |   5
+         8 | 55410 | 11082.0000000000000000 |   5
+         6 | 50867 | 10173.4000000000000000 |   5
+(4 rows)
 
 	
 -- GROUP BY on partition column where total number of projections are more than column count

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -259,8 +259,8 @@ SELECT title FROM articles
 	GROUP BY title
 	HAVING sum(word_count) > 18000
 	ORDER BY title;
-LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10038 WHERE true
    title    
 ------------
  alkylic
@@ -276,8 +276,8 @@ SELECT title, sum(word_count) AS corpus_size FROM articles
 	HAVING sum(word_count) > 2000
 	ORDER BY sum(word_count) DESC
 	LIMIT 5;
-LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10038 WHERE true
    title    | corpus_size 
 ------------+-------------
  anjanette  |       19519
@@ -291,8 +291,8 @@ LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 W
 SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING true
  author_id 
 -----------
          1
@@ -317,8 +317,8 @@ GROUP BY
 ORDER BY 
 	max(word_count), author_id  DESC 
 LIMIT 5;
-LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10036 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
 LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10038 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
  id | cnt 
 ----+-----
  16 |   1
@@ -332,8 +332,8 @@ LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING true
  author_id | count 
 -----------+-------
          1 |     5
@@ -354,8 +354,8 @@ SELECT author_id, (count(*) + author_id) as cnt FROM articles
 	GROUP BY author_id
 	HAVING (count(*) + author_id) > 4
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
 LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
  author_id | cnt 
 -----------+-----
          1 |   6
@@ -375,8 +375,8 @@ SELECT author_id, count(*) as cnt FROM articles
 	GROUP BY author_id
 	HAVING count(*) > 4 AND sum(author_id) > 30
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
  author_id | cnt 
 -----------+-----
          7 |   5
@@ -391,8 +391,8 @@ SELECT author_id, count(*) as cnt FROM articles
 	GROUP BY author_id
 	HAVING count(*) >= 5
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10038 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
  author_id | cnt 
 -----------+-----
         10 |   5
@@ -405,8 +405,8 @@ SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE (author_id > 5) GROUP BY author_id HAVING true
  author_id | double_single_int 
 -----------+-------------------
         10 |               225
@@ -423,8 +423,8 @@ SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_val
 	GROUP BY author_id
 	ORDER BY sum_two_ints(7, author_id::int) DESC
 	LIMIT 3;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10038 WHERE (author_id < 9) GROUP BY author_id HAVING true
  author_id | cnt | summed_value 
 -----------+-----+--------------
          8 |   5 |           15
@@ -438,8 +438,8 @@ SELECT author_id, word_count, count(*) as cnt FROM articles
 	WHERE author_id > 8 AND word_count > 8000
 	GROUP BY author_id, word_count
 	ORDER BY word_count DESC;	
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
 LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10038 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
  author_id | word_count | cnt 
 -----------+------------+-----
         10 |      19519 |   1
@@ -455,8 +455,8 @@ LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM 
 SELECT author_id, count(*), sum(author_id), avg(author_id), max(author_id) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE true
  author_id | count | sum |          avg           | max 
 -----------+-------+-----+------------------------+-----
          1 |     5 |   5 | 1.00000000000000000000 |   1

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -307,25 +307,26 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
         10
 (10 rows)
 
--- a query with GROUP BY on partition column where ORDER BY column must be pulled
-SELECT count(*) FROM articles
-	GROUP BY author_id
-	ORDER BY author_id;
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
- count 
--------
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-     5
-(10 rows)
+-- a query with GROUP BY on partition column where ORDER BY column(s) must be pulled
+SELECT 
+	id, count(*) as cnt FROM articles
+WHERE
+	author_id  > 0
+GROUP BY 
+	author_id, id
+ORDER BY 
+	max(word_count), author_id  DESC 
+LIMIT 5;
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10036 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+ id | cnt 
+----+-----
+ 16 |   1
+  9 |   1
+ 45 |   1
+ 18 |   1
+ 11 |   1
+(5 rows)
 
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -307,6 +307,26 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
         10
 (10 rows)
 
+-- a query with GROUP BY on partition column where ORDER BY column must be pulled
+SELECT count(*) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ count 
+-------
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+     5
+(10 rows)
+
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -291,8 +291,8 @@ LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 W
 SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  author_id 
 -----------
          1
@@ -311,8 +311,8 @@ LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE tru
 SELECT count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  count 
 -------
      5
@@ -331,8 +331,8 @@ LOG:  distributed statement: SELECT count(*) AS count, author_id FROM ONLY artic
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
  author_id | count 
 -----------+-------
          1 |     5
@@ -369,6 +369,21 @@ LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FRO
         10 |  15
 (10 rows)
 
+-- a query with multiple HAVING clauses
+SELECT author_id, count(*) as cnt FROM articles
+	GROUP BY author_id
+	HAVING count(*) > 4 AND sum(author_id) > 30
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+ author_id | cnt 
+-----------+-----
+         7 |   5
+         8 |   5
+         9 |   5
+        10 |   5
+(4 rows)
+
 -- a query with WHERE, HAVING and GROUP BY on partition column
 SELECT author_id, count(*) as cnt FROM articles
 	WHERE author_id > 8
@@ -389,8 +404,8 @@ SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id HAVING true
  author_id | double_single_int 
 -----------+-------------------
         10 |               225
@@ -407,8 +422,8 @@ SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_val
 	GROUP BY author_id
 	ORDER BY sum_two_ints(7, author_id::int) DESC
 	LIMIT 3;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id HAVING true
  author_id | cnt | summed_value 
 -----------+-----+--------------
          8 |   5 |           15
@@ -422,8 +437,8 @@ SELECT author_id, word_count, count(*) as cnt FROM articles
 	WHERE author_id > 8 AND word_count > 8000
 	GROUP BY author_id, word_count
 	ORDER BY word_count DESC;	
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
  author_id | word_count | cnt 
 -----------+------------+-----
         10 |      19519 |   1

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -221,21 +221,6 @@ SELECT COUNT(*) FROM articles;
     50
 (1 row)
 
--- try query with more SQL features
-SELECT author_id, sum(word_count) AS corpus_size FROM articles
-	GROUP BY author_id
-	HAVING sum(word_count) > 25000
-	ORDER BY sum(word_count) DESC
-	LIMIT 5;
- author_id | corpus_size 
------------+-------------
-         4 |       66325
-         2 |       61782
-        10 |       59955
-         8 |       55410
-         6 |       50867
-(5 rows)
-
 -- cross-shard queries on a foreign table should fail
 -- we'll just point the article shards to a foreign table
 BEGIN;
@@ -261,22 +246,197 @@ LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_10037 WHERE
     23
 (1 row)
 
-SET client_min_messages = DEFAULT;
-SET pg_shard.log_distributed_statements = DEFAULT;
--- use HAVING without its variable in target list
-SELECT author_id FROM articles
-	GROUP BY author_id
-	HAVING sum(word_count) > 50000
-	ORDER BY author_id;
- author_id 
------------
-         2
-         4
-         6
-         8
-        10
+-- function for tests
+CREATE OR REPLACE FUNCTION sum_two_ints(int,int) RETURNS int
+    AS $$ SELECT $1 + $2 $$
+    LANGUAGE SQL IMMUTABLE;
+-- function for tests
+CREATE OR REPLACE FUNCTION double_single_int(int) RETURNS int
+    AS $$ SELECT $1 * $1 $$
+    LANGUAGE SQL IMMUTABLE;
+-- use HAVING without its variable in target list when GROUP BY non-partition column
+SELECT title FROM articles
+	GROUP BY title
+	HAVING sum(word_count) > 18000
+	ORDER BY title;
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+   title    
+------------
+ alkylic
+ andesite
+ anjanette
+ archiblast
+ arsenous
 (5 rows)
 
+-- try query with more SQL features when GROUP BY non-partition column
+SELECT title, sum(word_count) AS corpus_size FROM articles
+	GROUP BY title
+	HAVING sum(word_count) > 2000
+	ORDER BY sum(word_count) DESC
+	LIMIT 5;
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+   title    | corpus_size 
+------------+-------------
+ anjanette  |       19519
+ andesite   |       19094
+ alkylic    |       18610
+ arsenous   |       18188
+ archiblast |       18185
+(5 rows)
+
+-- a simple query with GROUP BY on partition column
+SELECT author_id FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ author_id 
+-----------
+         1
+         2
+         3
+         4
+         5
+         6
+         7
+         8
+         9
+        10
+(10 rows)
+
+-- an aggregate query with GROUP BY on partition column
+SELECT author_id, count(*) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id
+ author_id | count 
+-----------+-------
+         1 |     5
+         2 |     5
+         3 |     5
+         4 |     5
+         5 |     5
+         6 |     5
+         7 |     5
+         8 |     5
+         9 |     5
+        10 |     5
+(10 rows)
+
+-- a query with HAVING and GROUP BY on partition column
+-- project column includes an aggregate in an operator expression 
+SELECT author_id, (count(*) + author_id) as cnt FROM articles
+	GROUP BY author_id
+	HAVING (count(*) + author_id) > 4
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+ author_id | cnt 
+-----------+-----
+         1 |   6
+         2 |   7
+         3 |   8
+         4 |   9
+         5 |  10
+         6 |  11
+         7 |  12
+         8 |  13
+         9 |  14
+        10 |  15
+(10 rows)
+
+-- a query with WHERE, HAVING and GROUP BY on partition column
+SELECT author_id, count(*) as cnt FROM articles
+	WHERE author_id > 8
+	GROUP BY author_id
+	HAVING count(*) >= 5
+	ORDER BY author_id DESC;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+ author_id | cnt 
+-----------+-----
+        10 |   5
+         9 |   5
+(2 rows)
+
+		
+-- a query with WHERE, function call with const value and GROUP BY on partition column
+SELECT author_id, double_single_int(15) FROM articles
+	WHERE author_id > 5
+	GROUP BY author_id
+	ORDER BY author_id DESC;
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id
+ author_id | double_single_int 
+-----------+-------------------
+        10 |               225
+         9 |               225
+         8 |               225
+         7 |               225
+         6 |               225
+(5 rows)
+
+		
+-- a query with WHERE, LIMIT, HAVING, function call on data and GROUP BY on partition column
+SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_value FROM articles
+	WHERE author_id < 9
+	GROUP BY author_id
+	ORDER BY sum_two_ints(7, author_id::int) DESC
+	LIMIT 3;
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id
+ author_id | cnt | summed_value 
+-----------+-----+--------------
+         8 |   5 |           15
+         7 |   5 |           14
+         6 |   5 |           13
+(3 rows)
+
+	
+-- a query with WHERE, HAVING, function call on data and GROUP BY on two columns including partition column
+SELECT author_id, word_count, count(*) as cnt FROM articles
+	WHERE author_id > 8 AND word_count > 8000
+	GROUP BY author_id, word_count
+	ORDER BY word_count DESC;	
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id
+ author_id | word_count | cnt 
+-----------+------------+-----
+        10 |      19519 |   1
+        10 |      17277 |   1
+        10 |      14976 |   1
+         9 |      10906 |   1
+         9 |       9524 |   1
+(5 rows)
+
+	
+-- GROUP BY on partition column where total number of projections are more than column count
+-- In this case, we do not push down GROUP BY
+SELECT author_id, count(*), sum(author_id), avg(author_id), max(author_id) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true
+ author_id | count | sum |          avg           | max 
+-----------+-------+-----+------------------------+-----
+         1 |     5 |   5 | 1.00000000000000000000 |   1
+         2 |     5 |  10 |     2.0000000000000000 |   2
+         3 |     5 |  15 |     3.0000000000000000 |   3
+         4 |     5 |  20 |     4.0000000000000000 |   4
+         5 |     5 |  25 |     5.0000000000000000 |   5
+         6 |     5 |  30 |     6.0000000000000000 |   6
+         7 |     5 |  35 |     7.0000000000000000 |   7
+         8 |     5 |  40 |     8.0000000000000000 |   8
+         9 |     5 |  45 |     9.0000000000000000 |   9
+        10 |     5 |  50 |    10.0000000000000000 |  10
+(10 rows)
+
+SET client_min_messages = DEFAULT;
+SET pg_shard.log_distributed_statements = DEFAULT;
 -- verify temp tables used by cross-shard queries do not persist
 SELECT COUNT(*) FROM pg_class WHERE relname LIKE 'pg_shard_temp_table%' AND
 									relkind = 'r';

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -259,8 +259,8 @@ SELECT title FROM articles
 	GROUP BY title
 	HAVING sum(word_count) > 18000
 	ORDER BY title;
-LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10038 WHERE true
    title    
 ------------
  alkylic
@@ -276,8 +276,8 @@ SELECT title, sum(word_count) AS corpus_size FROM articles
 	HAVING sum(word_count) > 2000
 	ORDER BY sum(word_count) DESC
 	LIMIT 5;
-LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10038 WHERE true
    title    | corpus_size 
 ------------+-------------
  anjanette  |       19519
@@ -291,8 +291,8 @@ LOG:  distributed statement: SELECT title, word_count FROM ONLY articles_10037 W
 SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING true
  author_id 
 -----------
          1
@@ -317,8 +317,8 @@ GROUP BY
 ORDER BY 
 	max(word_count), author_id  DESC 
 LIMIT 5;
-LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10036 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
 LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10037 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
+LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author_id FROM ONLY articles_10038 WHERE (author_id > 0) GROUP BY author_id, id HAVING true
  id | cnt 
 ----+-----
  16 |   1
@@ -332,8 +332,8 @@ LOG:  distributed statement: SELECT id, count(*) AS cnt, max(word_count), author
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS count FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING true
  author_id | count 
 -----------+-------
          1 |     5
@@ -354,8 +354,8 @@ SELECT author_id, (count(*) + author_id) as cnt FROM articles
 	GROUP BY author_id
 	HAVING (count(*) + author_id) > 4
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
 LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
+LOG:  distributed statement: SELECT author_id, (count(*) + author_id) AS cnt FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING ((count(*) + author_id) > 4)
  author_id | cnt 
 -----------+-----
          1 |   6
@@ -375,8 +375,8 @@ SELECT author_id, count(*) as cnt FROM articles
 	GROUP BY author_id
 	HAVING count(*) > 4 AND sum(author_id) > 30
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10038 WHERE true GROUP BY author_id HAVING ((count(*) > 4) AND (sum(author_id) > 30::numeric))
  author_id | cnt 
 -----------+-----
          7 |   5
@@ -391,8 +391,8 @@ SELECT author_id, count(*) as cnt FROM articles
 	GROUP BY author_id
 	HAVING count(*) >= 5
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10036 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10037 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt FROM ONLY articles_10038 WHERE (author_id > 8) GROUP BY author_id HAVING (count(*) >= 5)
  author_id | cnt 
 -----------+-----
         10 |   5
@@ -405,8 +405,8 @@ SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE (author_id > 5) GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE (author_id > 5) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE (author_id > 5) GROUP BY author_id HAVING true
  author_id | double_single_int 
 -----------+-------------------
         10 |               225
@@ -423,8 +423,8 @@ SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_val
 	GROUP BY author_id
 	ORDER BY sum_two_ints(7, author_id::int) DESC
 	LIMIT 3;
-LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10036 WHERE (author_id < 9) GROUP BY author_id HAVING true
 LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10037 WHERE (author_id < 9) GROUP BY author_id HAVING true
+LOG:  distributed statement: SELECT author_id, count(*) AS cnt, author_id AS summed_value FROM ONLY articles_10038 WHERE (author_id < 9) GROUP BY author_id HAVING true
  author_id | cnt | summed_value 
 -----------+-----+--------------
          8 |   5 |           15
@@ -438,8 +438,8 @@ SELECT author_id, word_count, count(*) as cnt FROM articles
 	WHERE author_id > 8 AND word_count > 8000
 	GROUP BY author_id, word_count
 	ORDER BY word_count DESC;	
-LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10036 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
 LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10037 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
+LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM ONLY articles_10038 WHERE ((author_id > 8) AND (word_count > 8000)) GROUP BY word_count, author_id HAVING true
  author_id | word_count | cnt 
 -----------+------------+-----
         10 |      19519 |   1
@@ -455,8 +455,8 @@ LOG:  distributed statement: SELECT author_id, word_count, count(*) AS cnt FROM 
 SELECT author_id, count(*), sum(author_id), avg(author_id), max(author_id) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
-LOG:  distributed statement: SELECT author_id FROM ONLY articles_10036 WHERE true
 LOG:  distributed statement: SELECT author_id FROM ONLY articles_10037 WHERE true
+LOG:  distributed statement: SELECT author_id FROM ONLY articles_10038 WHERE true
  author_id | count | sum |          avg           | max 
 -----------+-------+-----+------------------------+-----
          1 |     5 |   5 | 1.00000000000000000000 |   1

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -320,12 +320,8 @@ PgShardPlanner(Query *query, int cursorOptions, ParamListInfo boundParams)
 			 */
 			if (aggregatesPushedDown)
 			{
-				PVCAggregateBehavior aggregateBehavior = PVC_RECURSE_AGGREGATES;
-				PVCPlaceHolderBehavior placeHolderBehavior = PVC_RECURSE_PLACEHOLDERS;
-
-				distributedPlanTargetList = flatten_tlist(localQuery->targetList,
-														  aggregateBehavior,
-														  placeHolderBehavior);
+				distributedPlanTargetList = MasterTargetList(
+					distributedQuery->targetList);
 			}
 			else
 			{

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -849,9 +849,14 @@ BuildDistributedQuery(Query *query, List *remoteRestrictList, List *localRestric
 											safeToPushDownAggregate);
 	if (safeToPushDownAggregate)
 	{
-		filterQuery->groupClause = list_copy(query->groupClause);
-		filterQuery->havingQual = copyObject(query->havingQual);
 		filterQuery->hasAggs = true;
+		filterQuery->groupClause = list_copy(query->groupClause);
+
+		/*
+		 * Note that both havingQual is in implicitly-ANDed-list form
+		 * at this point, even though they are declared as Node.
+		*/
+		filterQuery->havingQual = (Node *) make_ands_explicit((List *) query->havingQual);
 	}
 
 	filterQuery->commandType = CMD_SELECT;

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -1049,9 +1049,9 @@ SortClauseReferencedByTargetEntry(List *sortClause, TargetEntry *targetEntry)
 static List *
 BuildDistributedTargetListWithoutAggregates(Query *query, List *localRestrictList)
 {
+	List *whereColumnList = NIL;
 	List *projectColumnList = NIL;
 	List *havingClauseColumnList = NIL;
-	List *whereColumnList = NIL;
 	List *requiredColumnList = NIL;
 	ListCell *columnCell = NULL;
 	List *uniqueColumnList = NIL;
@@ -1059,13 +1059,13 @@ BuildDistributedTargetListWithoutAggregates(Query *query, List *localRestrictLis
 	PVCAggregateBehavior aggregateBehavior = PVC_RECURSE_AGGREGATES;
 	PVCPlaceHolderBehavior placeHolderBehavior = PVC_REJECT_PLACEHOLDERS;
 
-	/* as well as any used in projections (GROUP BY, etc.) */
-	projectColumnList = pull_var_clause((Node *) query->targetList, aggregateBehavior,
-										placeHolderBehavior);
-
 	/* must retrieve all columns referenced by local WHERE clauses... */
 	whereColumnList = pull_var_clause((Node *) localRestrictList, aggregateBehavior,
 									  placeHolderBehavior);
+
+	/* as well as any used in projections (GROUP BY, etc.) */
+	projectColumnList = pull_var_clause((Node *) query->targetList, aggregateBehavior,
+										placeHolderBehavior);
 
 	/* finally, need those used in any HAVING quals */
 	havingClauseColumnList = pull_var_clause(query->havingQual, aggregateBehavior,

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -58,6 +58,7 @@
 #include "optimizer/cost.h"
 #include "optimizer/planner.h"
 #include "optimizer/var.h"
+#include "optimizer/tlist.h"
 #include "parser/analyze.h"
 #include "parser/parse_node.h"
 #include "parser/parsetree.h"
@@ -877,7 +878,6 @@ BuildDistributedTargetList(Query *query, List *localRestrictList,
 	{
 		List *aggregatedProjectColumnList = query->targetList;
 		ListCell *targetListCell = NULL;
-		ListCell *columnCell = NULL;
 		Index tableOrder = 1;
 		AttrNumber attributeNumber = 1;
 		List *targetEntryWhereColumns = TargetEntryList(whereColumnList);
@@ -887,9 +887,9 @@ BuildDistributedTargetList(Query *query, List *localRestrictList,
 		foreach(targetListCell, aggregatedTargetList)
 		{
 			TargetEntry *targetListEntry = (TargetEntry *) lfirst(targetListCell);
-			Expr *targetExpression = (Expr *) targetListEntry;
+			Expr *targetExpression = (Expr *) targetListEntry->expr;
 
-			if (IsA(targetListEntry->expr, Var) || IsA(targetListEntry->expr, Aggref))
+			if (IsA(targetExpression, Var) || IsA(targetExpression, Aggref))
 			{
 				targetList = lappend(targetList, targetListEntry);
 			}

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -1569,11 +1569,15 @@ ColumnDefinitionList(List *columnNameList, List *columnTypeList)
 		 */
 		Oid columnTypeId = InvalidOid;
 		int32 columnTypeMod = -1;
-		bool missingOK = false;
 		TypeName *typeName = NULL;
 		ColumnDef *columnDefinition = NULL;
 
+#if PG_VERSION_NUM <= 90300
+		parseTypeString(columnType, &columnTypeId, &columnTypeMod);
+#else
+		bool missingOK = false;
 		parseTypeString(columnType, &columnTypeId, &columnTypeMod, missingOK);
+#endif
 		typeName = makeTypeNameFromOid(columnTypeId, columnTypeMod);
 
 		/* we then create the column definition */

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -1572,7 +1572,7 @@ ColumnDefinitionList(List *columnNameList, List *columnTypeList)
 		TypeName *typeName = NULL;
 		ColumnDef *columnDefinition = NULL;
 
-#if PG_VERSION_NUM <= 90300
+#if PG_VERSION_NUM < 90400
 		parseTypeString(columnType, &columnTypeId, &columnTypeMod);
 #else
 		bool missingOK = false;

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -814,7 +814,10 @@ SafeToPushDownAggregate(Query *query, Oid distributedTableId)
 	bool safeToPushDownAggregates = false;
 	List *targetList = query->targetList;
 	List *groupClauseList = query->groupClause;
-	char *finalAttributeName = get_attname(distributedTableId, list_length(targetList));
+	List *rangeTableList = query->rtable;
+	RangeTblEntry *rangeTableEntry = (RangeTblEntry *) linitial(rangeTableList);
+	int tableColumnCount = list_length(rangeTableEntry->eref->colnames);
+	int targetListCount = list_length(targetList);
 
 	/*
 	 * standard_planner will be called on localQuery at PlanSequentialScan function.
@@ -824,7 +827,7 @@ SafeToPushDownAggregate(Query *query, Oid distributedTableId)
 	 *
 	 * Also, if GROUP BY does not present in the query, we cannot push down.
 	 */
-	if (finalAttributeName == NULL || groupClauseList == NIL)
+	if ((targetListCount > tableColumnCount) || groupClauseList == NIL)
 	{
 		safeToPushDownAggregates = false;
 	}

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -7,7 +7,7 @@
  *
  * Copyright (c) 2014-2015, Citus Data, Inc.
  *
- ****-------------------------------------------------------------------------
+ *****-------------------------------------------------------------------------
  */
 
 #include "postgres.h"
@@ -891,10 +891,10 @@ BuildDistributedTargetList(Query *query, List *localRestrictList,
 
 
 /*
-* BuildAggregatedDistributedTargetList returns a list of TargetEntry for the
-* distributed query when aggregates are pushed down. This function leaves
-* AggRefs as it is in the target list. Also, WHERE clause columns pushed down.
-*/
+ * BuildAggregatedDistributedTargetList returns a list of TargetEntry for the
+ * distributed query when aggregates are pushed down. This function leaves
+ * AggRefs as it is in the target list. Also, WHERE clause columns pushed down.
+ */
 static List *
 BuildAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 {
@@ -907,7 +907,7 @@ BuildAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 
 	/* must retrieve all columns referenced by local WHERE clauses... */
 	List *whereColumnList = pull_var_clause((Node *) localRestrictList, aggregateBehavior,
-									  	    placeHolderBehavior);
+											placeHolderBehavior);
 	List *whereTargetList = TargetEntryList(whereColumnList);
 
 	/* add WHERE clause list */
@@ -964,10 +964,10 @@ BuildAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 
 
 /*
-* BuildNonAggregatedDistributedTargetList returns a list of TargetEntry for the
-* distributed query when aggregates are not pushed down. This function replaces all
-* target entries with Vars. Also, WHERE and HAVING clauses columns pushed down.
-*/
+ * BuildNonAggregatedDistributedTargetList returns a list of TargetEntry for the
+ * distributed query when aggregates are not pushed down. This function replaces all
+ * target entries with Vars. Also, WHERE and HAVING clauses columns pushed down.
+ */
 static List *
 BuildNonAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 {
@@ -984,9 +984,11 @@ BuildNonAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 	/* as well as any used in projections (GROUP BY, etc.) */
 	projectColumnList = pull_var_clause((Node *) query->targetList, aggregateBehavior,
 										placeHolderBehavior);
+
 	/* must retrieve all columns referenced by local WHERE clauses... */
 	whereColumnList = pull_var_clause((Node *) localRestrictList, aggregateBehavior,
 									  placeHolderBehavior);
+
 	/* finally, need those used in any HAVING quals */
 	havingClauseColumnList = pull_var_clause(query->havingQual, aggregateBehavior,
 											 placeHolderBehavior);
@@ -1022,6 +1024,7 @@ BuildNonAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 
 	return targetList;
 }
+
 
 /*
  * BuildLocalQuery returns a copy of query with its quals replaced by those
@@ -1356,7 +1359,7 @@ TargetEntryVarList(List *targetEntryList)
 	List *newTargetEntryList = NIL;
 
 	projectColumnList = pull_var_clause((Node *) targetEntryList,
-												  aggregateBehavior, placeHolderBehavior);
+										aggregateBehavior, placeHolderBehavior);
 	newTargetEntryList = TargetEntryList(projectColumnList);
 
 	return newTargetEntryList;
@@ -1412,7 +1415,7 @@ CreateTemporaryTableStmtFromQuery(Query *query)
 	temporaryTableId++;
 
 	projectColumnList = pull_var_clause((Node *) query->targetList, aggregateBehavior,
-									    placeHolderBehavior);
+										placeHolderBehavior);
 
 	foreach(projectColumnListCell, projectColumnList)
 	{

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -106,7 +106,7 @@ static Query * BuildDistributedQuery(Query *query, List *remoteRestrictList,
 									 List *localRestrictList,
 									 bool safeToPushDownAggregate);
 static List * BuildDistributedTargetList(Query *query, List *localRestrictList,
-								 	     bool safeToPushDownAggregate);
+										 bool safeToPushDownAggregate);
 static Query * BuildLocalQuery(Query *query, List *localRestrictList,
 							   bool safeToPushDownAggregate);
 static Query * RemoveAggregates(Query *aggregatedQuery);
@@ -898,9 +898,9 @@ BuildDistributedTargetList(Query *query, List *localRestrictList,
 				TargetEntry *aggregatedTargetEntry = NULL;
 				Var *targetVar = makeVarFromTargetEntry(tableOrder, targetListEntry);
 
-				aggregatedTargetEntry = makeTargetEntry((Expr *)targetVar,
+				aggregatedTargetEntry = makeTargetEntry((Expr *) targetVar,
 														attributeNumber,
-													    targetListEntry->resname,
+														targetListEntry->resname,
 														targetListEntry->resjunk);
 
 				targetList = lappend(targetList, aggregatedTargetEntry);
@@ -1004,9 +1004,9 @@ RemoveAggregates(Query *aggregatedQuery)
 		TargetEntry *aggregatedTargetEntry = NULL;
 		Var *targetVar = makeVarFromTargetEntry(tableOrder, targetListEntry);
 
-		aggregatedTargetEntry = makeTargetEntry((Expr *)targetVar, attributeNumber,
-											    targetListEntry->resname,
-											    targetListEntry->resjunk);
+		aggregatedTargetEntry = makeTargetEntry((Expr *) targetVar, attributeNumber,
+												targetListEntry->resname,
+												targetListEntry->resjunk);
 
 		/* ressortgroupref must be updated for ORDER BY columns */
 		if (targetListEntry->ressortgroupref != 0)
@@ -1021,7 +1021,6 @@ RemoveAggregates(Query *aggregatedQuery)
 		 */
 		if (targetListEntry->resjunk == false)
 		{
-
 			nonAggregatedTargetList = lappend(nonAggregatedTargetList,
 											  aggregatedTargetEntry);
 			++attributeNumber;
@@ -1225,8 +1224,8 @@ TargetEntryList(List *expressionList)
 	foreach(expressionCell, expressionList)
 	{
 		Expr *expression = (Expr *) lfirst(expressionCell);
-		TargetEntry *targetEntry = makeTargetEntry(expression, -1, NULL, false);
 
+		TargetEntry *targetEntry = makeTargetEntry(expression, -1, NULL, false);
 		targetEntryList = lappend(targetEntryList, targetEntry);
 	}
 
@@ -1255,6 +1254,7 @@ CreateTemporaryTable(Query *localQuery, Query *distributedQuery, bool pushDownAg
 
 	return createStmt;
 }
+
 
 /*
  * CreateTemporaryTableStmtFromQuery returns a CreateStmt node which will create
@@ -1315,7 +1315,6 @@ CreateTemporaryTableStmtFromQuery(Query *query)
 
 		++columnCount;
 		columnList = lappend(columnList, columnDefinition);
-
 	}
 
 	relation = makeRangeVar(NULL, tableName->data, -1);
@@ -1386,7 +1385,6 @@ BuildDistributedPlan(Query *query, List *shardIntervalList)
 	List *taskList = NIL;
 	DistributedPlan *distributedPlan = palloc0(sizeof(DistributedPlan));
 	distributedPlan->plan.type = (NodeTag) T_DistributedPlan;
-	//distributedPlan->targetList = query->targetList;
 
 	foreach(shardIntervalCell, shardIntervalList)
 	{

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -898,7 +898,6 @@ BuildAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 {
 	List *targetList = query->targetList;
 	List *newTargetList = NIL;
-	List *uniqueVarTargetList = NIL;
 	ListCell *targetListCell = NULL;
 	PVCAggregateBehavior aggregateBehavior = PVC_RECURSE_AGGREGATES;
 	PVCPlaceHolderBehavior placeHolderBehavior = PVC_REJECT_PLACEHOLDERS;
@@ -933,18 +932,6 @@ BuildAggregatedDistributedTargetList(Query *query, List *localRestrictList)
 			{
 				/* this is equivalent of pulling Vars from non-aggregated expressions */
 				Var *targetVar = (Var *) lfirst(targetVarListCell);
-				bool targetVarExists = list_member(uniqueVarTargetList, targetVar);
-				bool sortOrGroupReference = targetListEntry->ressortgroupref;
-
-				if (targetVarExists && !sortOrGroupReference)
-				{
-					continue;
-				}
-				else
-				{
-					uniqueVarTargetList = list_append_unique(uniqueVarTargetList,
-															 targetVar);
-				}
 
 				newTargetEntry = makeTargetEntry((Expr *) targetVar, -1,
 												 targetListEntry->resname,

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -931,7 +931,7 @@ BuildDistributedQuery(Query *query, List *remoteRestrictList, List *localRestric
 
 
 /*
- * BuildDistributedTargetListWithAggregates returns a list of TargetEntry for the
+ * BuildDistributedTargetListWithAggregates returns a TargetEntry list for the
  * distributed query when aggregates are pushed down. This function leaves
  * AggRefs as it is in the target list. Also, WHERE clause columns pushed down.
  */

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -205,15 +205,11 @@ SELECT author_id FROM articles
 	ORDER BY author_id;
 
 -- a query with GROUP BY on partition column where ORDER BY column(s) must be pulled
-SELECT 
-	id, count(*) as cnt FROM articles
-WHERE
-	author_id  > 0
-GROUP BY 
-	author_id, id
-ORDER BY 
-	max(word_count), author_id  DESC 
-LIMIT 5;
+SELECT  min(id), count(*) as cnt FROM articles
+	WHERE author_id  > 0
+	GROUP BY author_id
+	ORDER BY max(word_count), author_id  DESC 
+	LIMIT 5;
 
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles
@@ -254,10 +250,11 @@ SELECT author_id, count(*) as cnt, sum_two_ints(7, author_id::int) as summed_val
 	LIMIT 3;
 	
 -- a query with WHERE, HAVING, function call on data and GROUP BY on two columns including partition column
-SELECT author_id, word_count, count(*) as cnt FROM articles
-	WHERE author_id > 8 AND word_count > 8000
-	GROUP BY author_id, word_count
-	ORDER BY word_count DESC;	
+SELECT author_id, sum(word_count), avg(word_count), count(*) as cnt FROM articles
+	WHERE author_id > 3
+	GROUP BY author_id
+	HAVING sum(word_count) > 8000 AND max(word_count) > 15000
+	ORDER BY sum(word_count) DESC;	
 	
 -- GROUP BY on partition column where total number of projections are more than column count
 -- In this case, we do not push down GROUP BY

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -224,7 +224,7 @@ SELECT author_id, count(*) as cnt FROM articles
 	ORDER BY author_id DESC;
 		
 -- a query with WHERE, function call with const value and GROUP BY on partition column
-SELECT author_id, double_single_int(author_id::int + 15) FROM articles
+SELECT author_id, double_single_int(15) FROM articles
 	WHERE author_id > 5
 	GROUP BY author_id
 	ORDER BY author_id DESC;

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -204,6 +204,11 @@ SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
 
+-- a query with GROUP BY on partition column where ORDER BY column must be pulled
+SELECT count(*) FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles
 	GROUP BY author_id

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -209,6 +209,12 @@ SELECT author_id, count(*) FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
 
+-- GROUP BY on partition column where total number of projections are more than column count
+-- In this case, we do not push down GROUP BY
+SELECT author_id, count(*), sum(author_id), avg(author_id), max(author_id)  FROM articles
+	GROUP BY author_id
+	ORDER BY author_id;
+
 -- a query with HAVING and GROUP BY on partition column
 SELECT author_id, count(*) as cnt FROM articles
 	GROUP BY author_id

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -204,10 +204,16 @@ SELECT author_id FROM articles
 	GROUP BY author_id
 	ORDER BY author_id;
 
--- a query with GROUP BY on partition column where ORDER BY column must be pulled
-SELECT count(*) FROM articles
-	GROUP BY author_id
-	ORDER BY author_id;
+-- a query with GROUP BY on partition column where ORDER BY column(s) must be pulled
+SELECT 
+	id, count(*) as cnt FROM articles
+WHERE
+	author_id  > 0
+GROUP BY 
+	author_id, id
+ORDER BY 
+	max(word_count), author_id  DESC 
+LIMIT 5;
 
 -- an aggregate query with GROUP BY on partition column
 SELECT author_id, count(*) FROM articles

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -221,6 +221,12 @@ SELECT author_id, (count(*) + author_id) as cnt FROM articles
 	HAVING (count(*) + author_id) > 4
 	ORDER BY author_id;
 
+-- a query with multiple HAVING clauses
+SELECT author_id, count(*) as cnt FROM articles
+	GROUP BY author_id
+	HAVING count(*) > 4 AND sum(author_id) > 30
+	ORDER BY author_id;
+
 -- a query with WHERE, HAVING and GROUP BY on partition column
 SELECT author_id, count(*) as cnt FROM articles
 	WHERE author_id > 8


### PR DESCRIPTION
This PR is intended for the following : 
Users should be able to exploit computational power of worker nodes in servicing aggregates. At minimum, if a `GROUP BY` is present which references the partition column, we should be able to create a query containing certain safe aggregates.