### PR TITLE
Switch to signed integers for all identifiers

### DIFF
--- a/ddl_commands.h
+++ b/ddl_commands.h
@@ -28,9 +28,9 @@
 /* function declarations to extend DDL commands with shard IDs */
 extern List * TableDDLCommandList(Oid relationId);
 extern void AppendOptionListToString(StringInfo stringBuffer, List *optionList);
-extern List * ExtendedDDLCommandList(Oid masterRelationId, uint64 shardId,
+extern List * ExtendedDDLCommandList(Oid masterRelationId, int64 shardId,
 									 List *sqlCommandList);
-extern void AppendShardIdToName(char **name, uint64 shardId);
+extern void AppendShardIdToName(char **name, int64 shardId);
 extern bool ExecuteRemoteCommandList(char *nodeName, uint32 nodePort,
 									 List *sqlCommandList);
 

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -205,7 +205,7 @@ LoadShardInterval(int64 shardId)
  * an error if the specified shard has not been placed.
  */
 List *
-LoadFinalizedShardPlacementList(uint64 shardId)
+LoadFinalizedShardPlacementList(int64 shardId)
 {
 	List *finalizedPlacementList = NIL;
 	List *shardPlacementList = LoadShardPlacementList(shardId);
@@ -653,7 +653,7 @@ CreateShardRow(Oid distributedTableId, char shardStorage, text *shardMinValue,
  * supplied values and returns the primary key of that new row.
  */
 int64
-CreateShardPlacementRow(uint64 shardId, ShardState shardState, char *nodeName,
+CreateShardPlacementRow(int64 shardId, ShardState shardState, char *nodeName,
 						uint32 nodePort)
 {
 	int64 newShardPlacementId = -1;
@@ -693,7 +693,7 @@ CreateShardPlacementRow(uint64 shardId, ShardState shardState, char *nodeName,
  * placement identifier, erroring out if it cannot find such a row.
  */
 void
-DeleteShardPlacementRow(uint64 shardPlacementId)
+DeleteShardPlacementRow(int64 shardPlacementId)
 {
 	Oid argTypes[] = { INT8OID };
 	Datum argValues[] = { Int64GetDatum(shardPlacementId) };

--- a/distribution_metadata.h
+++ b/distribution_metadata.h
@@ -117,7 +117,7 @@ typedef struct ShardIntervalListCacheEntry
 extern List * LookupShardIntervalList(Oid distributedTableId);
 extern List * LoadShardIntervalList(Oid distributedTableId);
 extern ShardInterval * LoadShardInterval(int64 shardId);
-extern List * LoadFinalizedShardPlacementList(uint64 shardId);
+extern List * LoadFinalizedShardPlacementList(int64 shardId);
 extern List * LoadShardPlacementList(int64 shardId);
 extern Var * PartitionColumn(Oid distributedTableId);
 extern char PartitionType(Oid distributedTableId);
@@ -128,9 +128,9 @@ extern void InsertPartitionRow(Oid distributedTableId, char partitionType,
 							   text *partitionKeyText);
 extern int64 CreateShardRow(Oid distributedTableId, char shardStorage,
 							text *shardMinValue, text *shardMaxValue);
-extern int64 CreateShardPlacementRow(uint64 shardId, ShardState shardState,
+extern int64 CreateShardPlacementRow(int64 shardId, ShardState shardState,
 									 char *nodeName, uint32 nodePort);
-extern void DeleteShardPlacementRow(uint64 shardPlacementId);
+extern void DeleteShardPlacementRow(int64 shardPlacementId);
 extern void UpdateShardPlacementRowState(int64 shardPlacementId, ShardState newState);
 extern void LockShard(int64 shardId, LOCKMODE lockMode);
 

--- a/extend_ddl_commands.c
+++ b/extend_ddl_commands.c
@@ -46,9 +46,9 @@
 
 /* local function forward declarations */
 static Node * ParseTreeNode(const char *ddlCommand);
-static void ExtendDDLCommand(Node *parseTree, uint64 shardId);
+static void ExtendDDLCommand(Node *parseTree, int64 shardId);
 static bool TypeAddIndexConstraint(const AlterTableCmd *command);
-static void AppendShardIdToConstraintName(AlterTableCmd *command, uint64 shardId);
+static void AppendShardIdToConstraintName(AlterTableCmd *command, int64 shardId);
 static char * DeparseDDLCommand(Node *ddlCommandNode, Oid masterRelationId);
 static char * DeparseAlterTableStmt(AlterTableStmt *alterTableStmt);
 static char * DeparseIndexConstraint(Constraint *constraint);
@@ -65,7 +65,7 @@ static char * DeparseIndexStmt(IndexStmt *indexStmt, Oid masterRelationId);
  * deparses the extended parse node back into a SQL string.
  */
 List *
-ExtendedDDLCommandList(Oid masterRelationId, uint64 shardId, List *ddlCommandList)
+ExtendedDDLCommandList(Oid masterRelationId, int64 shardId, List *ddlCommandList)
 {
 	List *extendedDDLCommandList = NIL;
 	ListCell *ddlCommandCell = NULL;
@@ -113,7 +113,7 @@ ParseTreeNode(const char *ddlCommand)
  * has the side effect of extending relation names in the parse tree.
  */
 static void
-ExtendDDLCommand(Node *parseTree, uint64 shardId)
+ExtendDDLCommand(Node *parseTree, int64 shardId)
 {
 	NodeTag nodeType = nodeTag(parseTree);
 
@@ -260,7 +260,7 @@ TypeAddIndexConstraint(const AlterTableCmd *command)
  * calling this function.
  */
 static void
-AppendShardIdToConstraintName(AlterTableCmd *command, uint64 shardId)
+AppendShardIdToConstraintName(AlterTableCmd *command, int64 shardId)
 {
 	if (command->subtype == AT_AddConstraint)
 	{
@@ -282,12 +282,12 @@ AppendShardIdToConstraintName(AlterTableCmd *command, uint64 shardId)
  * memory context the name was originally created in.
  */
 void
-AppendShardIdToName(char **name, uint64 shardId)
+AppendShardIdToName(char **name, int64 shardId)
 {
 	char extendedName[NAMEDATALEN];
 	uint32 extendedNameLength = 0;
 
-	snprintf(extendedName, NAMEDATALEN, "%s%c" UINT64_FORMAT,
+	snprintf(extendedName, NAMEDATALEN, "%s%c" INT64_FORMAT,
 			 (*name), SHARD_NAME_SEPARATOR, shardId);
 
 	/*

--- a/prune_shard_list.c
+++ b/prune_shard_list.c
@@ -117,7 +117,7 @@ PruneShardList(Oid relationId, List *whereClauseList, List *shardIntervalList)
 		if (shardPruned)
 		{
 			ereport(DEBUG2, (errmsg("predicate pruning for shard with ID "
-									UINT64_FORMAT, shardInterval->id)));
+									INT64_FORMAT, shardInterval->id)));
 		}
 		else
 		{

--- a/test/distribution_metadata.c
+++ b/test/distribution_metadata.c
@@ -292,7 +292,7 @@ create_monolithic_shard_row(PG_FUNCTION_ARGS)
 Datum
 create_healthy_local_shard_placement_row(PG_FUNCTION_ARGS)
 {
-	uint64 shardId = (uint64) PG_GETARG_INT64(0);
+	int64 shardId = PG_GETARG_INT64(0);
 	int64 newShardPlacementId = CreateShardPlacementRow(shardId, STATE_FINALIZED,
 														"localhost", 5432);
 
@@ -306,7 +306,7 @@ create_healthy_local_shard_placement_row(PG_FUNCTION_ARGS)
 Datum
 delete_shard_placement_row(PG_FUNCTION_ARGS)
 {
-	uint64 shardPlacementId = (uint64) PG_GETARG_INT64(0);
+	int64 shardPlacementId = PG_GETARG_INT64(0);
 
 	DeleteShardPlacementRow(shardPlacementId);
 
@@ -321,7 +321,7 @@ delete_shard_placement_row(PG_FUNCTION_ARGS)
 Datum
 update_shard_placement_row_state(PG_FUNCTION_ARGS)
 {
-	uint64 shardPlacementId = (uint64) PG_GETARG_INT64(0);
+	int64 shardPlacementId = PG_GETARG_INT64(0);
 	ShardState shardState = (ShardState) PG_GETARG_INT32(1);
 
 	UpdateShardPlacementRowState(shardPlacementId, shardState);


### PR DESCRIPTION
PostgreSQL doesn't have unsigned types, so using them when storing a value in a table doesn't make sense.