### PR TITLE
Clarify confusing PL/pgSQL error message

### DIFF
--- a/expected/queries.out
+++ b/expected/queries.out
@@ -214,6 +214,22 @@ ERROR:  could not plan SELECT query
 DETAIL:  Configured to use CitusDB's SELECT logic, but CitusDB is not installed.
 HINT:  Install CitusDB or set the "use_citusdb_select_logic" configuration parameter to "false".
 SET pg_shard.use_citusdb_select_logic TO false;
+-- test use of EXECUTE statements within plpgsql
+DO $sharded_execute$
+	BEGIN
+		EXECUTE 'SELECT COUNT(*) FROM articles ' ||
+				'WHERE author_id = $1 AND author_id = $2' USING 1, 2;
+	END
+$sharded_execute$;
+-- test use of bare SQL within plpgsql
+DO $sharded_sql$
+	BEGIN
+		SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+	END
+$sharded_sql$;
+ERROR:  unrecognized node type: 2100
+CONTEXT:  SQL statement "SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2"
+PL/pgSQL function inline_code_block line 3 at SQL statement
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
  count 

--- a/expected/queries.out
+++ b/expected/queries.out
@@ -227,7 +227,9 @@ DO $sharded_sql$
 		SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
 	END
 $sharded_sql$;
-ERROR:  unrecognized node type: 2100
+ERROR:  cannot cache distributed plan
+DETAIL:  PL/pgSQL's statement caching is unsupported by pg_shard.
+HINT:  Bypass caching by using the EXECUTE keyword instead.
 CONTEXT:  SQL statement "SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2"
 PL/pgSQL function inline_code_block line 3 at SQL statement
 -- test cross-shard queries

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -214,6 +214,22 @@ SET pg_shard.use_citusdb_select_logic TO true;
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 ERROR:  cannot plan queries that include both regular and partitioned relations
 SET pg_shard.use_citusdb_select_logic TO false;
+-- test use of EXECUTE statements within plpgsql
+DO $sharded_execute$
+	BEGIN
+		EXECUTE 'SELECT COUNT(*) FROM articles ' ||
+				'WHERE author_id = $1 AND author_id = $2' USING 1, 2;
+	END
+$sharded_execute$;
+-- test use of bare SQL within plpgsql
+DO $sharded_sql$
+	BEGIN
+		SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+	END
+$sharded_sql$;
+ERROR:  unrecognized node type: 2100
+CONTEXT:  SQL statement "SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2"
+PL/pgSQL function inline_code_block line 3 at SQL statement
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
  count 

--- a/expected/queries_1.out
+++ b/expected/queries_1.out
@@ -227,7 +227,9 @@ DO $sharded_sql$
 		SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
 	END
 $sharded_sql$;
-ERROR:  unrecognized node type: 2100
+ERROR:  cannot cache distributed plan
+DETAIL:  PL/pgSQL's statement caching is unsupported by pg_shard.
+HINT:  Bypass caching by using the EXECUTE keyword instead.
 CONTEXT:  SQL statement "SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2"
 PL/pgSQL function inline_code_block line 3 at SQL statement
 -- test cross-shard queries

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -220,15 +220,15 @@ _PG_init(void)
 static void
 SetupPLErrorTransformation(PLpgSQL_execstate *estate, PLpgSQL_function *func)
 {
-	MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);
-	ErrorContextCallback *pgShardErrorContext = palloc0(sizeof(ErrorContextCallback));
+	ErrorContextCallback *pgShardErrorContext = NULL;
+	pgShardErrorContext = MemoryContextAllocZero(TopTransactionContext,
+												 sizeof(ErrorContextCallback));
 
 	pgShardErrorContext->previous = error_context_stack;
 	pgShardErrorContext->callback = PgShardErrorTransform;
 	pgShardErrorContext->arg = NULL;
 
 	error_context_stack = pgShardErrorContext;
-	MemoryContextSwitchTo(oldContext);
 }
 
 

--- a/pg_shard.c
+++ b/pg_shard.c
@@ -214,8 +214,7 @@ _PG_init(void)
 
 /*
  * SetupPLErrorTransformation is intended to run before entering PL/pgSQL
- * functions. It pushes an error transform onto the error context stack and
- * stashes away the current memory context for use within that transform.
+ * functions. It pushes an error transform onto the error context stack.
  */
 static void
 SetupPLErrorTransformation(PLpgSQL_execstate *estate, PLpgSQL_function *func)

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -149,6 +149,21 @@ SET pg_shard.use_citusdb_select_logic TO true;
 SELECT title, authors.name FROM authors, articles WHERE authors.id = articles.author_id;
 SET pg_shard.use_citusdb_select_logic TO false;
 
+-- test use of EXECUTE statements within plpgsql
+DO $sharded_execute$
+	BEGIN
+		EXECUTE 'SELECT COUNT(*) FROM articles ' ||
+				'WHERE author_id = $1 AND author_id = $2' USING 1, 2;
+	END
+$sharded_execute$;
+
+-- test use of bare SQL within plpgsql
+DO $sharded_sql$
+	BEGIN
+		SELECT COUNT(*) FROM articles WHERE author_id = 1 AND author_id = 2;
+	END
+$sharded_sql$;
+
 -- test cross-shard queries
 SELECT COUNT(*) FROM articles;
 


### PR DESCRIPTION
When a user attempts to interact with a `pg_shard`-distributed table using bare SQL in PL/pgSQL, they receive a confusing error message of _unrecognized node type: 2100_. We've had several users raise this issue and it's certainly possible additional customers just think PL/pgSQL support is broken entirely and haven't said anything.

The underlying issue is that PL/pgSQL caches plans for all static SQL appearing within functions. `pg_shard` uses a "custom" plan type (just an integer tag well above those used by PostgreSQL) so the caching methods fail. In the normal course of things we intercept e.g. `PREPARE` statements to keep users from caching plans, but PL/pgSQL bypasses that path and uses SPI's caching machinery directly.

I looked briefly into cramming the distributed plan into some other plan that can be cached and even thought about using `queryId` as some sort of index into a place we can actually pass along the plan during query processing, but ultimately those approaches leave a lot to be desired and felt all-around hacky.

After that I tried using a transaction callback to replace the confusing error message, but it's unsafe to call `CopyErrorData` if no error has occurred, so an explicit `ROLLBACK` statement could trigger my callback even when no error has occurred.

Finally, I learned of `emit_log_hook`, which would make it trivial to replace the error message, except it only executes if a message is destined for the log. If—for whatever reason—a system is configured to not send `ERROR` to the log destination, the hook is not invoked, leaving the misleading error in place.

So I landed upon using a combination of `error_context_stack` (actually a chain of handlers called during error handling) and `PLpgSQL_plugin` (intended to facilitate PL/pgSQL debugger and profiler development). The handler simply detects the error code and message of this misleading case and augments the error information with hints, details, and a better code and message. This solution has the benefit that it does not (yet) change our execution/caching paths and replaces all instances of the offending message rather cleanly (or so I think).