### PR TITLE
Disable unused parameter compiler warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS = connection.o create_shards.o citus_metadata_sync.o distribution_metadata.
 	   extend_ddl_commands.o generate_ddl_commands.o pg_shard.o prune_shard_list.o \
 	   repair_shards.o ruleutils.o
 
-PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -I$(libpq_srcdir)
+PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -I$(libpq_srcdir)
 
 # pg_shard and CitusDB have several functions that share the same name. When we
 # link pg_shard against CitusDB on Linux, the loader resolves to the CitusDB

--- a/distribution_metadata.c
+++ b/distribution_metadata.c
@@ -22,10 +22,7 @@
 #include "access/attnum.h"
 #include "access/htup.h"
 #include "access/tupdesc.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "executor/spi.h"
-#pragma GCC diagnostic pop
 #include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "nodes/makefuncs.h"

--- a/test/distribution_metadata.c
+++ b/test/distribution_metadata.c
@@ -219,7 +219,7 @@ is_distributed_table(PG_FUNCTION_ARGS)
  * tables whatsoever.
  */
 Datum
-distributed_tables_exist(PG_FUNCTION_ARGS __attribute__((unused)))
+distributed_tables_exist(PG_FUNCTION_ARGS)
 {
 	bool distributedTablesExist = DistributedTablesExist();
 

--- a/test/fake_fdw.c
+++ b/test/fake_fdw.c
@@ -30,9 +30,6 @@
 #include "optimizer/restrictinfo.h"
 #include "utils/palloc.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 /* local function forward declarations */
 static void FakeGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel,
 								  Oid foreigntableid);
@@ -144,6 +141,3 @@ FakeReScanForeignScan(ForeignScanState *node) { }
  */
 static void
 FakeEndForeignScan(ForeignScanState *node) { }
-
-
-#pragma GCC diagnostic pop


### PR DESCRIPTION
@anarazel asked for this in #121.

This warning isn't as useful as the other unused warnings (such as
unused variables) and it was getting to be more trouble than it was
worth. This removes it entirely and cuts out any extra source that
was previously needed to opt-in to unused parameters.