### PR TITLE
Lock metadata during cluster structural changes

### DIFF
--- a/include/distribution_metadata.h
+++ b/include/distribution_metadata.h
@@ -114,6 +114,11 @@ typedef struct ShardIntervalListCacheEntry
 } ShardIntervalListCacheEntry;
 
 
+/*
+ * ShardLockType specifies the kinds of locks that can be acquired for a given
+ * shard, i.e. one to change data in that shard or a lock to change placements
+ * of the shard itself (the shard's metadata).
+ */
 typedef enum
 {
 	SHARD_LOCK_INVALID_FIRST = 0,

--- a/include/distribution_metadata.h
+++ b/include/distribution_metadata.h
@@ -122,8 +122,8 @@ typedef struct ShardIntervalListCacheEntry
 typedef enum
 {
 	SHARD_LOCK_INVALID_FIRST = 0,
-	SHARD_LOCK_DATA = 1,
-	SHARD_LOCK_METADATA = 2
+	SHARD_LOCK_DATA = 3,
+	SHARD_LOCK_METADATA = 4
 } ShardLockType;
 
 /* function declarations to access and manipulate the metadata */

--- a/include/distribution_metadata.h
+++ b/include/distribution_metadata.h
@@ -114,6 +114,13 @@ typedef struct ShardIntervalListCacheEntry
 } ShardIntervalListCacheEntry;
 
 
+typedef enum
+{
+	SHARD_LOCK_INVALID_FIRST = 0,
+	SHARD_LOCK_DATA = 1,
+	SHARD_LOCK_METADATA = 2
+} ShardLockType;
+
 /* function declarations to access and manipulate the metadata */
 extern List * LookupShardIntervalList(Oid distributedTableId);
 extern List * LoadShardIntervalList(Oid distributedTableId);
@@ -133,7 +140,8 @@ extern int64 CreateShardPlacementRow(int64 shardId, ShardState shardState,
 									 char *nodeName, uint32 nodePort);
 extern void DeleteShardPlacementRow(int64 shardPlacementId);
 extern void UpdateShardPlacementRowState(int64 shardPlacementId, ShardState newState);
-extern void LockShard(int64 shardId, LOCKMODE lockMode);
-
+extern void LockShardData(int64 shardId, LOCKMODE lockMode);
+extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
+extern void LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode);
 
 #endif /* PG_SHARD_DISTRIBUTION_METADATA_H */

--- a/src/distribution_metadata.c
+++ b/src/distribution_metadata.c
@@ -836,6 +836,12 @@ LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode)
 }
 
 
+/*
+ * AcquireShardLock implements the shared logic needed by LockShardData and
+ * LockShardDistributionMetadata. It builds a lock tag with a shard identifier
+ * (bound to the current database) and specified shard lock type, then blocks
+ * to acquire the corresponding lock in the specified mode.
+ */
 static void
 AcquireShardLock(int64 shardId, ShardLockType shardLockType, LOCKMODE lockMode)
 {

--- a/src/distribution_metadata.c
+++ b/src/distribution_metadata.c
@@ -827,11 +827,6 @@ LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode)
 {
 	Assert(lockMode == ExclusiveLock || lockMode == ShareLock);
 
-	if (lockMode == ExclusiveLock)
-	{
-		lockMode = AccessExclusiveLock;
-	}
-
 	(void) LockRelationOid(relationId, lockMode);
 }
 
@@ -855,7 +850,7 @@ AcquireShardLock(int64 shardId, ShardLockType shardLockType, LOCKMODE lockMode)
 	memset(&lockTag, 0, sizeof(LOCKTAG));
 
 	Assert(lockMode == ExclusiveLock || lockMode == ShareLock);
-	Assert(shardLockType = !SHARD_LOCK_INVALID_FIRST);
+	Assert(shardLockType != SHARD_LOCK_INVALID_FIRST);
 
 	SET_LOCKTAG_ADVISORY(lockTag, MyDatabaseId, keyUpperHalf, keyLowerHalf,
 						 (uint16) shardLockType);

--- a/src/pg_shard.c
+++ b/src/pg_shard.c
@@ -1151,6 +1151,7 @@ BuildDistributedPlan(Query *query, List *shardIntervalList)
 		ShardInterval *shardInterval = (ShardInterval *) lfirst(shardIntervalCell);
 		int64 shardId = shardInterval->id;
 		List *finalizedPlacementList = NIL;
+		FromExpr *joinTree = NULL;
 		Task *task = NULL;
 		StringInfo queryString = makeStringInfo();
 
@@ -1165,7 +1166,7 @@ BuildDistributedPlan(Query *query, List *shardIntervalList)
 		 * before we deparse the query. This applies to SELECT, UPDATE and
 		 * DELETE statements.
 		 */
-		FromExpr *joinTree = query->jointree;
+		joinTree = query->jointree;
 		if ((joinTree != NULL) && (joinTree->quals != NULL))
 		{
 			Node *whereClause = joinTree->quals;

--- a/src/pg_shard.c
+++ b/src/pg_shard.c
@@ -1390,7 +1390,7 @@ AcquireExecutorShardLocks(List *taskList, LOCKMODE lockMode)
 		Task *task = (Task *) lfirst(taskCell);
 		int64 shardId = task->shardId;
 
-		LockShard(shardId, lockMode);
+		LockShardData(shardId, lockMode);
 	}
 }
 

--- a/src/pg_shard.c
+++ b/src/pg_shard.c
@@ -726,9 +726,6 @@ DistributedQueryShardList(Query *query)
 	Oid distributedTableId = ExtractFirstDistributedTableId(query);
 	List *shardIntervalList = NIL;
 
-	/* acquire lock to ensure no shards can be added during execution */
-	LockRelationDistributionMetadata(distributedTableId, ShareLock);
-
 	/* error out if no shards exist for the table */
 	shardIntervalList = LookupShardIntervalList(distributedTableId);
 	if (shardIntervalList == NIL)

--- a/src/repair_shards.c
+++ b/src/repair_shards.c
@@ -93,8 +93,14 @@ master_copy_shard_placement(PG_FUNCTION_ARGS)
 	 */
 	LockShardData(shardId, ExclusiveLock);
 
-	shardPlacementList = LoadShardPlacementList(shardId);
+	/*
+	 * We've stopped data modifications of this shard, but we plan to move
+	 * a placement to the healthy state, so we need to grab a shard metadata
+	 * lock (in exclusive mode) as well.
+	 */
+	LockShardDistributionMetadata(shardId, ExclusiveLock);
 
+	shardPlacementList = LoadShardPlacementList(shardId);
 	sourcePlacement = SearchShardPlacementInList(shardPlacementList, sourceNodeName,
 												 sourceNodePort);
 	if (sourcePlacement->shardState != STATE_FINALIZED)

--- a/src/repair_shards.c
+++ b/src/repair_shards.c
@@ -91,7 +91,7 @@ master_copy_shard_placement(PG_FUNCTION_ARGS)
 	 * (INSERT, UPDATE, or DELETE) and prevent concurrent repair operations from
 	 * being able to operate on this shard.
 	 */
-	LockShard(shardId, ExclusiveLock);
+	LockShardData(shardId, ExclusiveLock);
 
 	shardPlacementList = LoadShardPlacementList(shardId);
 

--- a/test/src/distribution_metadata.c
+++ b/test/src/distribution_metadata.c
@@ -377,7 +377,7 @@ acquire_shared_shard_lock(PG_FUNCTION_ARGS)
 {
 	int64 shardId = PG_GETARG_INT64(0);
 
-	LockShard(shardId, ShareLock);
+	LockShardData(shardId, ShareLock);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
The guiding principle here is that readers must know about a relevant set of objects to perform distributed queries so need guarantees that the relevant set will not change beneath them during said queries.

In practice, this means we need two locks: one for the set of shards related to a relation and one for the set of placements related to a shard. If the caller intends to add shards (or (active) placements), they must hold an exclusive lock on the grouping relation (or shard). If the caller just wants to act on the current set of shards (or the (active) placements), they need a shared lock before reading.

I explored using row locks to accomplish this but they'd be just as arbitrary as some advisory lock with the added downside that they can cause disk writes. `LockDatabaseObject` promised to provide a more structured way to specify what we're locking, but it is usually called with a `relid`-`objid` pair, each half of which is 32-bits. This provides two problems:

  * The adapter layer between `pg_shard` and CitusDB's metadata is implemented with a view, so we couldn't blindly use a `relid`: we'd have to get the `relid` of the underlying query if the metadata table in question is a view instead of a normal relation. This is a bit of extra code.
  * Shard identifiers are 64-bits and so do not fit in the space afforded by a call to `LockDatabaseObject` (assuming the first parameter is a `relid`). We could has the shard identifier to fit in 32-bits, but that's again extra code

Ultimately I decided just using an `AccessExclusive` lock on the relation itself was sufficient to signal we're reading or changing that relation's shard set (use of an `AccessExclusive` lock here is analogous to PostgreSQL's own use of that level for most table schema changes). The lock used to read or change placements of a shard is an advisory lock comprised of the database identifier, the shard identifier, and a lock type (metadata or actual data).