### PR TITLE
Use CitusDB SELECT logic by default within CitusDB

### DIFF
--- a/include/pg_shard.h
+++ b/include/pg_shard.h
@@ -15,12 +15,20 @@
 #include "c.h"
 
 #include "access/tupdesc.h"
+#include "catalog/indexing.h"
 #include "nodes/parsenodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/plannodes.h"
 #include "lib/stringinfo.h"
 #include "utils/tuplestore.h"
 
+
+/* detect when building against CitusDB */
+#ifdef DistPartitionLogicalRelidIndexId
+#define BUILT_AGAINST_CITUSDB true
+#else
+#define BUILT_AGAINST_CITUSDB false
+#endif
 
 /* prefix used for temporary tables created on the master node */
 #define TEMPORARY_TABLE_PREFIX "pg_shard_temp_table"

--- a/src/pg_shard.c
+++ b/src/pg_shard.c
@@ -197,8 +197,8 @@ _PG_init(void)
 
 	DefineCustomBoolVariable("pg_shard.use_citusdb_select_logic",
 							 "Informs pg_shard to use CitusDB's select logic", NULL,
-							 &UseCitusDBSelectLogic, false, PGC_USERSET, 0, NULL,
-							 NULL, NULL);
+							 &UseCitusDBSelectLogic, BUILT_AGAINST_CITUSDB, PGC_USERSET,
+							 0, NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pg_shard.log_distributed_statements",
 							 "Logs each statement used in a distributed plan", NULL,

--- a/test/expected/00-init.out
+++ b/test/expected/00-init.out
@@ -2,6 +2,8 @@
 -- create extension
 -- ===================================================================
 CREATE EXTENSION pg_shard;
+-- ensure the test DB defaults to pg_shard select logic
+ALTER DATABASE :DBNAME SET pg_shard.use_citusdb_select_logic TO false;
 -- create fake fdw for use in tests
 CREATE FUNCTION fake_fdw_handler()
 RETURNS fdw_handler

--- a/test/sql/00-init.sql
+++ b/test/sql/00-init.sql
@@ -4,6 +4,9 @@
 
 CREATE EXTENSION pg_shard;
 
+-- ensure the test DB defaults to pg_shard select logic
+ALTER DATABASE :DBNAME SET pg_shard.use_citusdb_select_logic TO false;
+
 -- create fake fdw for use in tests
 CREATE FUNCTION fake_fdw_handler()
 RETURNS fdw_handler


### PR DESCRIPTION
The `use_citusdb_select_logic` configuration parameter defaults false, which is causing confusion now that pg_shard sees and understands all CitusDB metadata. This detects CitusDB at build time and defaults the configuration to true when pg_shard is built against CitusDB.

Resolves #132