### PR TITLE
Use master's port if worker port config absent

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -20,8 +20,9 @@
 /* maximum duration to wait for connection */
 #define CLIENT_CONNECT_TIMEOUT_SECONDS "5"
 
-/* maximum (textual) lengths of hostname */
+/* maximum (textual) lengths of hostname and port */
 #define MAX_NODE_LENGTH 255
+#define MAX_PORT_LENGTH 10
 
 /* times to attempt connection (or reconnection) */
 #define MAX_CONNECT_ATTEMPTS 2

--- a/src/create_shards.c
+++ b/src/create_shards.c
@@ -379,9 +379,10 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 	List *workerNodeList = NIL;
 	char workerNodeLine[MAXPGPATH];
 	char *workerFilePath = make_absolute_path(workerNodeFilename);
+	char *workerPatternTemplate = "%%%u[^# \t]%%*[ \t]%%%u[^# \t]";
 	char workerLinePattern[1024];
-	const int WorkerNameIndex = 0;
-	const int WorkerPortIndex = 1;
+	const int workerNameIndex = 0;
+	const int workerPortIndex = 1;
 	memset(workerLinePattern, '\0', sizeof(workerLinePattern));
 
 	workerFileStream = AllocateFile(workerFilePath, PG_BINARY_R);
@@ -393,7 +394,7 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 	}
 
 	/* build pattern to contain node name length limit */
-	snprintf(workerLinePattern, sizeof(workerLinePattern), "%%%us%%*[ \t]%%%us",
+	snprintf(workerLinePattern, sizeof(workerLinePattern), workerPatternTemplate,
 			 MAX_NODE_LENGTH, MAX_PORT_LENGTH);
 
 	while (fgets(workerNodeLine, sizeof(workerNodeLine), workerFileStream) != NULL)
@@ -402,6 +403,7 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 		char *linePointer = NULL;
 		uint32 nodePort = PostPortNumber; /* default port number */
 		int fieldCount = 0;
+		bool lineIsInvalid = false;
 		char nodeName[MAX_NODE_LENGTH + 1];
 		char nodePortString[MAX_PORT_LENGTH + 1];
 		memset(nodeName, '\0', sizeof(nodeName));
@@ -414,7 +416,7 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 								   "length of %d", MAXPGPATH)));
 		}
 
-		/* skip leading whitespace and check for # comment */
+		/* skip leading whitespace */
 		for (linePointer = workerNodeLine; *linePointer; linePointer++)
 		{
 			if (!isspace((unsigned char) *linePointer))
@@ -423,32 +425,28 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 			}
 		}
 
+		/* if the entire line is whitespace or a comment, skip it */
 		if (*linePointer == '\0' || *linePointer == '#')
 		{
 			continue;
 		}
 
 		/* parse line; node name is required, but port is optional */
-		fieldCount = sscanf(workerNodeLine, workerLinePattern, nodeName, nodePortString);
+		fieldCount = sscanf(linePointer, workerLinePattern, nodeName, nodePortString);
 
 		/* adjust field count for zero based indexes */
 		fieldCount--;
 
 		/* raise error if no fields were assigned */
-		if (fieldCount < WorkerNameIndex)
+		if (fieldCount < workerNameIndex)
 		{
-			ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
-							errmsg("could not parse worker node line: %s",
-								   workerNodeLine),
-							errhint("Lines in the worker node file consist of a node "
-									"name and optional port separated by whitespace. "
-									"Lines starting with a '#' character are skipped.")));
+			lineIsInvalid = true;
 		}
 
 		/* no special treatment for nodeName: already parsed by sscanf */
 
 		/* if a second token was specified, convert to integer port */
-		if (fieldCount >= WorkerPortIndex && *nodePortString != '#')
+		if (fieldCount >= workerPortIndex && *nodePortString != '#')
 		{
 			char *nodePortEnd = NULL;
 
@@ -457,14 +455,19 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 
 			if (errno != 0 || (*nodePortEnd) != '\0')
 			{
-				ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
-								errmsg("could not parse worker node line: %s",
-									   workerNodeLine),
-								errhint("Lines in the worker node file consist of a node "
-										"name and optional port separated by whitespace. "
-										"Lines starting with a '#' character are "
-										"skipped.")));
+				lineIsInvalid = true;
 			}
+		}
+
+		if (lineIsInvalid)
+		{
+			ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
+							errmsg("could not parse worker node line: %s",
+								   workerNodeLine),
+							errhint("Lines in the worker node file consist of a node "
+									"name and optional port separated by whitespace. "
+									"Comments begin with a '#' character and extend to "
+									"the end of their line.")));
 		}
 
 		/* allocate worker node structure and set fields */

--- a/src/create_shards.c
+++ b/src/create_shards.c
@@ -455,7 +455,7 @@ ParseWorkerNodeFile(char *workerNodeFilename)
 		/* no special treatment for nodeName: already parsed by sscanf */
 
 		/* if a second token was specified, convert to integer port */
-		if (fieldCount >= workerPortIndex && *nodePortString != '#')
+		if (fieldCount >= workerPortIndex)
 		{
 			char *nodePortEnd = NULL;
 

--- a/test/launcher.sh
+++ b/test/launcher.sh
@@ -33,7 +33,7 @@ then
 fi
 
 sed -i.bak -e's/^/#/g' -e"\$a\\
-localhost $PGPORT # added by installcheck\\
+localhost # added by installcheck\\
 adeadhost 5432 # added by installcheck" $PG_WORKER_LIST_CONF
 
 shift


### PR DESCRIPTION
CitusDB allows lines in `pg_worker_list.conf` to omit the port number, whereas `pg_shard` required it: confusing (or annoying) users of both.

This changes the `sscanf` format string to parse both the node name and node port as strings. If no node port is specified (or if that token starts with `#` i.e. begins a line comment), the default port is used; otherwise, we parse the node port string into an integer in precisely the same fashion used by CitusDB.

The reviewer of this request should consult the CitusDB functions `LoadWorkerNodeList` and `ParseWorkerNodeLine` in `worker_node_manager.c` to verify that the `pg_shard` implementation faithfully emulates CitusDB's implementation. Note that CitusDB uses functions from `hba.c` that are inaccessible to `pg_shard`, which is why the implementations differ.

I've removed the port number from the `pg_worker_list.conf` generated by our test launcher in order to exercise the new behavior.