### PR TITLE
Prevent dropping distributed tables

### DIFF
--- a/include/distribution_metadata.h
+++ b/include/distribution_metadata.h
@@ -148,5 +148,6 @@ extern void UpdateShardPlacementRowState(int64 shardPlacementId, ShardState newS
 extern void LockShardData(int64 shardId, LOCKMODE lockMode);
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 extern void LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode);
+extern void DeleteDistributedTableMetadata(Oid relationId);
 
 #endif /* PG_SHARD_DISTRIBUTION_METADATA_H */

--- a/include/distribution_metadata.h
+++ b/include/distribution_metadata.h
@@ -148,6 +148,6 @@ extern void UpdateShardPlacementRowState(int64 shardPlacementId, ShardState newS
 extern void LockShardData(int64 shardId, LOCKMODE lockMode);
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 extern void LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode);
-extern void DeleteDistributedTableMetadata(Oid relationId);
+extern void DeletePartitionMetadata(Oid relationId);
 
 #endif /* PG_SHARD_DISTRIBUTION_METADATA_H */

--- a/src/distribution_metadata.c
+++ b/src/distribution_metadata.c
@@ -55,9 +55,7 @@ static ShardPlacement * TupleToShardPlacement(HeapTuple heapTuple,
 											  TupleDesc tupleDescriptor);
 static void AcquireShardLock(int64 shardId, ShardLockType shardLockType,
 							 LOCKMODE lockMode);
-static void DeleteShardPlacementMetadata(Oid relationId);
-static void DeleteShardMetadata(Oid relationId);
-static void DeletePartitionMetadata(Oid relationId);
+
 
 
 /*
@@ -836,68 +834,10 @@ LockRelationDistributionMetadata(Oid relationId, LOCKMODE lockMode)
 
 
 /*
- * DeleteDistributedTableMetadata removes all the metadata including partition,
- * shard(s) and shard placement(s) that belong to the distributed table identified by
- * relationId.
- */
-void
-DeleteDistributedTableMetadata(Oid relationId)
-{
-	/* order of the calls is important due to foreign keys on metadata tables */
-	DeleteShardPlacementMetadata(relationId);
-	DeleteShardMetadata(relationId);
-	DeletePartitionMetadata(relationId);
-}
-
-
-/*
- * DeleteShardPlacementMetadata removes the row(s) from shard_placement table
- * which belongs to the distributed table identified by relationId.
- */
-static void
-DeleteShardPlacementMetadata(Oid relationId)
-{
-	Oid argTypes[] = { OIDOID };
-	Datum argValues[] = { DatumGetUInt32(relationId) };
-	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-
-	SPI_connect();
-
-	SPI_execute_with_args("DELETE FROM pgs_distribution_metadata.shard_placement WHERE "
-						  "shard_id IN (SELECT id FROM pgs_distribution_metadata.shard "
-						  "WHERE relation_id = $1)", argCount, argTypes, argValues, NULL,
-						  false, 0);
-
-	SPI_finish();
-}
-
-
-/*
- * DeleteShardMetadata removes the row(s) from shard table which belongs to the
- * distributed table identified by relationId.
- */
-static void
-DeleteShardMetadata(Oid relationId)
-{
-	Oid argTypes[] = { OIDOID };
-	Datum argValues[] = { DatumGetUInt32(relationId) };
-	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-
-	SPI_connect();
-
-	SPI_execute_with_args("DELETE FROM pgs_distribution_metadata.shard WHERE "
-						  "relation_id = $1", argCount, argTypes, argValues, NULL,
-						  false, 0);
-
-	SPI_finish();
-}
-
-
-/*
  * DeletePartitionMetadata removes the row from partition table which belongs to the
  * distributed table identified by relationId.
  */
-static void
+void
 DeletePartitionMetadata(Oid relationId)
 {
 	Oid argTypes[] = { OIDOID };

--- a/src/pg_shard.c
+++ b/src/pg_shard.c
@@ -2241,7 +2241,7 @@ ErrorOnDropIfDistributedTablesExist(DropStmt *dropStatement)
 /*
  * ErrorOnDropDistributedTable prevents attempts to DROP distributed tables.
  * This prevention will be circumvented if the user includes the CASCADE
- * option in their DROP command, in which case metadata belonging to the distributed
+ * option in their DROP command, in which case partition row belonging to the distributed
  * table is deleted, a notice is printed and the DROP is allowed to proceed.
  */
 static void
@@ -2271,8 +2271,8 @@ ErrorOnDropDistributedTable(DropStmt *dropStatement)
 
 		if (dropStatement->behavior == DROP_CASCADE)
 		{
-			/* delete the metadata belonging to the table */
-			DeleteDistributedTableMetadata(tableId);
+			/* delete the partition row belonging to the table */
+			DeletePartitionMetadata(tableId);
 
 			/* if CASCADE was used, emit NOTICE and proceed with DROP */
 			ereport(NOTICE, (errmsg("shards remain on worker nodes"),

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -300,17 +300,17 @@ SELECT key FROM pgs_distribution_metadata.partition;
 
 -- observe that shards and placements still exist for simple_table
 SELECT
-    s.id, node_name, node_port
+    s.id, node_name
 FROM
     pgs_distribution_metadata.shard s LEFT OUTER JOIN pg_class c ON s.relation_id = c.oid,
     pgs_distribution_metadata.shard_placement p
 WHERE
     c.oid IS NULL AND s.id = p.shard_id;
-   id   | node_name | node_port 
---------+-----------+-----------
- 102042 | localhost |      5432
- 102043 | localhost |      5432
- 102044 | localhost |      5432
- 102045 | localhost |      5432
+   id   | node_name 
+--------+-----------
+ 102042 | localhost
+ 102043 | localhost
+ 102044 | localhost
+ 102045 | localhost
 (4 rows)
 

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -258,3 +258,59 @@ DELETE FROM pgs_distribution_metadata.shard
 	
 DELETE FROM pgs_distribution_metadata.partition
 	WHERE relation_id = 'foreign_table_to_distribute'::regclass;	
+-- test DROP TABLE
+CREATE TABLE simple_table (
+	id int
+);
+SELECT master_create_distributed_table('simple_table', 'id');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('simple_table', 4, 1);
+WARNING:  Connection failed to adeadhost:5432
+DETAIL:  Remote message: could not translate host name "adeadhost" to address: Name or service not known
+WARNING:  could not create shard on "adeadhost:5432"
+WARNING:  Connection failed to adeadhost:5432
+DETAIL:  Remote message: could not translate host name "adeadhost" to address: Name or service not known
+WARNING:  could not create shard on "adeadhost:5432"
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+-- we cannot drop distributed table without CASCADE modifier
+DROP TABLE simple_table;
+ERROR:  cannot drop distributed table simple_table because other objects depend on it
+DETAIL:  Existing metadata depends on table simple_table
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+-- now drop with CASCADE
+DROP TABLE simple_table CASCADE;
+NOTICE:  shards remain on worker nodes
+DETAIL:  Shards created by simple_table table are not removed by DROP TABLE.
+-- observe that no partitions exists for simple_table
+SELECT pg_class.relname FROM pgs_distribution_metadata.partition
+	LEFT OUTER JOIN pg_class ON (relation_id = oid)
+	WHERE pg_class.relname = 'simple_table';
+ relname 
+---------
+(0 rows)
+
+-- observe that no shards exists for simple_table
+SELECT DISTINCT(pg_class.relname) FROM pgs_distribution_metadata.shard
+	LEFT OUTER JOIN pg_class ON (relation_id = oid)
+	WHERE pg_class.relname = 'simple_table';
+ relname 
+---------
+(0 rows)
+
+-- observe that no shard placements exists for simple_table
+SELECT * FROM pgs_distribution_metadata.shard_placement
+	WHERE shard_id NOT IN (SELECT pg_class.oid FROM pgs_distribution_metadata.shard
+			       LEFT OUTER JOIN pg_class ON (relation_id = oid)
+			       WHERE pg_class.relname = 'simple_table');
+ id | shard_id | shard_state | node_name | node_port 
+----+----------+-------------+-----------+-----------
+(0 rows)
+

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -260,9 +260,9 @@ DELETE FROM pgs_distribution_metadata.partition
 	WHERE relation_id = 'foreign_table_to_distribute'::regclass;	
 -- test DROP TABLE
 CREATE TABLE simple_table (
-	id int
+	simple_table_key int
 );
-SELECT master_create_distributed_table('simple_table', 'id');
+SELECT master_create_distributed_table('simple_table', 'simple_table_key');
  master_create_distributed_table 
 ---------------------------------
  
@@ -290,27 +290,27 @@ DROP TABLE simple_table CASCADE;
 NOTICE:  shards remain on worker nodes
 DETAIL:  Shards created by simple_table table are not removed by DROP TABLE.
 -- observe that no partitions exists for simple_table
-SELECT pg_class.relname FROM pgs_distribution_metadata.partition
-	LEFT OUTER JOIN pg_class ON (relation_id = oid)
-	WHERE pg_class.relname = 'simple_table';
- relname 
----------
-(0 rows)
+SELECT key FROM pgs_distribution_metadata.partition;
+ key  
+------
+ name
+ id
+ name
+(3 rows)
 
--- observe that no shards exists for simple_table
-SELECT DISTINCT(pg_class.relname) FROM pgs_distribution_metadata.shard
-	LEFT OUTER JOIN pg_class ON (relation_id = oid)
-	WHERE pg_class.relname = 'simple_table';
- relname 
----------
-(0 rows)
-
--- observe that no shard placements exists for simple_table
-SELECT * FROM pgs_distribution_metadata.shard_placement
-	WHERE shard_id NOT IN (SELECT pg_class.oid FROM pgs_distribution_metadata.shard
-			       LEFT OUTER JOIN pg_class ON (relation_id = oid)
-			       WHERE pg_class.relname = 'simple_table');
- id | shard_id | shard_state | node_name | node_port 
-----+----------+-------------+-----------+-----------
-(0 rows)
+-- observe that shards and placements still exist for simple_table
+SELECT
+    s.id, node_name, node_port
+FROM
+    pgs_distribution_metadata.shard s LEFT OUTER JOIN pg_class c ON s.relation_id = c.oid,
+    pgs_distribution_metadata.shard_placement p
+WHERE
+    c.oid IS NULL AND s.id = p.shard_id;
+   id   | node_name | node_port 
+--------+-----------+-----------
+ 102042 | localhost |      5432
+ 102043 | localhost |      5432
+ 102044 | localhost |      5432
+ 102045 | localhost |      5432
+(4 rows)
 

--- a/test/expected/09-queries.out
+++ b/test/expected/09-queries.out
@@ -268,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102049 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102050 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/test/expected/09-queries_1.out
+++ b/test/expected/09-queries_1.out
@@ -268,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102049 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102050 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/test/sql/05-create_shards.sql
+++ b/test/sql/05-create_shards.sql
@@ -174,7 +174,7 @@ SELECT key FROM pgs_distribution_metadata.partition;
 
 -- observe that shards and placements still exist for simple_table
 SELECT
-    s.id, node_name, node_port
+    s.id, node_name
 FROM
     pgs_distribution_metadata.shard s LEFT OUTER JOIN pg_class c ON s.relation_id = c.oid,
     pgs_distribution_metadata.shard_placement p

--- a/test/sql/05-create_shards.sql
+++ b/test/sql/05-create_shards.sql
@@ -153,3 +153,35 @@ DELETE FROM pgs_distribution_metadata.shard
 	
 DELETE FROM pgs_distribution_metadata.partition
 	WHERE relation_id = 'foreign_table_to_distribute'::regclass;	
+
+-- test DROP TABLE
+CREATE TABLE simple_table (
+	id int
+);
+
+SELECT master_create_distributed_table('simple_table', 'id');
+
+SELECT master_create_worker_shards('simple_table', 4, 1);
+
+-- we cannot drop distributed table without CASCADE modifier
+DROP TABLE simple_table;
+
+-- now drop with CASCADE
+DROP TABLE simple_table CASCADE;
+
+-- observe that no partitions exists for simple_table
+SELECT pg_class.relname FROM pgs_distribution_metadata.partition
+	LEFT OUTER JOIN pg_class ON (relation_id = oid)
+	WHERE pg_class.relname = 'simple_table';
+
+-- observe that no shards exists for simple_table
+SELECT DISTINCT(pg_class.relname) FROM pgs_distribution_metadata.shard
+	LEFT OUTER JOIN pg_class ON (relation_id = oid)
+	WHERE pg_class.relname = 'simple_table';
+
+-- observe that no shard placements exists for simple_table
+SELECT * FROM pgs_distribution_metadata.shard_placement
+	WHERE shard_id NOT IN (SELECT pg_class.oid FROM pgs_distribution_metadata.shard
+			       LEFT OUTER JOIN pg_class ON (relation_id = oid)
+			       WHERE pg_class.relname = 'simple_table');
+


### PR DESCRIPTION
This PR aims to prevent attempts to DROP distributed tables. This prevention will be circumvented if the user includes the CASCADE option in their DROP command, in which case partition row belonging to the distributed table is deleted, a notice is printed and the DROP is allowed to proceed.

Note that only *partition* metadata is removed. Shard and shard placement metadata are preserved for:
*  Better compliance with CitusDB 
* Enable users to find shards on the workers even if the distributed tables are dropped

Next step for removing/dropping is already discussed [here](https://github.com/citusdata/pg_shard/issues/1).