### PR TITLE
Fix hash token distribution algorithm

### DIFF
--- a/include/create_shards.h
+++ b/include/create_shards.h
@@ -20,6 +20,9 @@
 #include "nodes/pg_list.h"
 
 
+/* total number of hash tokens (2^32) */
+#define HASH_TOKEN_COUNT INT64CONST(4294967296UL)
+
 /* name for the file containing worker node and port information */
 #define WORKER_LIST_FILENAME "pg_worker_list.conf"
 

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -290,7 +290,7 @@ WARNING:  could not create shard on "adeadhost:5432"
 -- pg_shard ensures all shards are roughly the same size
 SELECT max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
-	WHERE relation_id='weird_shard_count'::regclass
+	WHERE relation_id = 'weird_shard_count'::regclass
 	ORDER BY min_value::integer ASC;
  shard_size 
 ------------

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -120,26 +120,37 @@ WARNING:  could not create shard on "adeadhost:5432"
 \set VERBOSITY default
 SELECT storage, min_value, max_value FROM pgs_distribution_metadata.shard
 	WHERE relation_id = 'table_to_distribute'::regclass
-	ORDER BY (min_value COLLATE "C") ASC;
+	ORDER BY (min_value::integer) ASC;
  storage |  min_value  |  max_value  
 ---------+-------------+-------------
- t       | -1073741828 | -805306374
- t       | -1342177283 | -1073741829
- t       | -1610612738 | -1342177284
- t       | -1879048193 | -1610612739
- t       | -2147483648 | -1879048194
- t       | -268435463  | -9
- t       | -536870918  | -268435464
- t       | -8          | 268435446
- t       | -805306373  | -536870919
- t       | 1073741812  | 1342177266
- t       | 1342177267  | 1610612721
- t       | 1610612722  | 1879048176
- t       | 1879048177  | 2147483647
- t       | 268435447   | 536870901
- t       | 536870902   | 805306356
- t       | 805306357   | 1073741811
+ t       | -2147483648 | -1879048193
+ t       | -1879048192 | -1610612737
+ t       | -1610612736 | -1342177281
+ t       | -1342177280 | -1073741825
+ t       | -1073741824 | -805306369
+ t       | -805306368  | -536870913
+ t       | -536870912  | -268435457
+ t       | -268435456  | -1
+ t       | 0           | 268435455
+ t       | 268435456   | 536870911
+ t       | 536870912   | 805306367
+ t       | 805306368   | 1073741823
+ t       | 1073741824  | 1342177279
+ t       | 1342177280  | 1610612735
+ t       | 1610612736  | 1879048191
+ t       | 1879048192  | 2147483647
 (16 rows)
+
+-- all shards should have the same size (16 divides evenly into the hash space)
+SELECT count(*) AS shard_count,
+	max_value::integer-min_value::integer AS shard_size
+	FROM pgs_distribution_metadata.shard
+	WHERE relation_id='table_to_distribute'::regclass
+	GROUP BY shard_size;
+ shard_count | shard_size 
+-------------+------------
+          16 |  268435455
+(1 row)
 
 -- all shards should be on a single node
 WITH unique_nodes AS (
@@ -227,26 +238,70 @@ WARNING:  could not create shard on "adeadhost:5432"
 \set VERBOSITY default
 SELECT storage, min_value, max_value FROM pgs_distribution_metadata.shard
 	WHERE relation_id = 'foreign_table_to_distribute'::regclass
-	ORDER BY (min_value COLLATE "C") ASC;
+	ORDER BY (min_value::integer) ASC;
  storage |  min_value  |  max_value  
 ---------+-------------+-------------
- f       | -1073741828 | -805306374
- f       | -1342177283 | -1073741829
- f       | -1610612738 | -1342177284
- f       | -1879048193 | -1610612739
- f       | -2147483648 | -1879048194
- f       | -268435463  | -9
- f       | -536870918  | -268435464
- f       | -8          | 268435446
- f       | -805306373  | -536870919
- f       | 1073741812  | 1342177266
- f       | 1342177267  | 1610612721
- f       | 1610612722  | 1879048176
- f       | 1879048177  | 2147483647
- f       | 268435447   | 536870901
- f       | 536870902   | 805306356
- f       | 805306357   | 1073741811
+ f       | -2147483648 | -1879048193
+ f       | -1879048192 | -1610612737
+ f       | -1610612736 | -1342177281
+ f       | -1342177280 | -1073741825
+ f       | -1073741824 | -805306369
+ f       | -805306368  | -536870913
+ f       | -536870912  | -268435457
+ f       | -268435456  | -1
+ f       | 0           | 268435455
+ f       | 268435456   | 536870911
+ f       | 536870912   | 805306367
+ f       | 805306368   | 1073741823
+ f       | 1073741824  | 1342177279
+ f       | 1342177280  | 1610612735
+ f       | 1610612736  | 1879048191
+ f       | 1879048192  | 2147483647
 (16 rows)
+
+-- test shard creation using weird shard count
+CREATE TABLE weird_shard_count
+(
+	name text,
+	id bigint
+);
+\set VERBOSITY terse
+SELECT master_create_distributed_table('weird_shard_count', 'id');
+ master_create_distributed_table 
+---------------------------------
+ 
+(1 row)
+
+SELECT master_create_worker_shards('weird_shard_count', 7, 1);
+WARNING:  Connection failed to adeadhost:5432
+WARNING:  could not create shard on "adeadhost:5432"
+WARNING:  Connection failed to adeadhost:5432
+WARNING:  could not create shard on "adeadhost:5432"
+WARNING:  Connection failed to adeadhost:5432
+WARNING:  could not create shard on "adeadhost:5432"
+WARNING:  Connection failed to adeadhost:5432
+WARNING:  could not create shard on "adeadhost:5432"
+ master_create_worker_shards 
+-----------------------------
+ 
+(1 row)
+
+\set VERBOSITY default
+-- pg_shard ensures all shards are roughly the same size
+SELECT max_value::integer-min_value::integer AS shard_size
+	FROM pgs_distribution_metadata.shard
+	WHERE relation_id='weird_shard_count'::regclass
+	ORDER BY min_value::integer ASC;
+ shard_size 
+------------
+  613566755
+  613566755
+  613566755
+  613566755
+  613566755
+  613566755
+  613566759
+(7 rows)
 
 -- cleanup foreign table, related shards and shard placements
 DELETE FROM pgs_distribution_metadata.shard_placement

--- a/test/expected/05-create_shards.out
+++ b/test/expected/05-create_shards.out
@@ -143,7 +143,7 @@ SELECT storage, min_value, max_value FROM pgs_distribution_metadata.shard
 
 -- all shards should have the same size (16 divides evenly into the hash space)
 SELECT count(*) AS shard_count,
-	max_value::integer-min_value::integer AS shard_size
+	max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
 	WHERE relation_id='table_to_distribute'::regclass
 	GROUP BY shard_size;
@@ -288,7 +288,7 @@ WARNING:  could not create shard on "adeadhost:5432"
 
 \set VERBOSITY default
 -- pg_shard ensures all shards are roughly the same size
-SELECT max_value::integer-min_value::integer AS shard_size
+SELECT max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
 	WHERE relation_id='weird_shard_count'::regclass
 	ORDER BY min_value::integer ASC;

--- a/test/expected/09-queries.out
+++ b/test/expected/09-queries.out
@@ -268,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102052 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102053 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/test/expected/09-queries_1.out
+++ b/test/expected/09-queries_1.out
@@ -268,8 +268,8 @@ ROLLBACK;
 SET pg_shard.log_distributed_statements = on;
 SET client_min_messages = log;
 SELECT count(*) FROM articles WHERE word_count > 10000;
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102045 WHERE (word_count > 10000)
-LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102046 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102052 WHERE (word_count > 10000)
+LOG:  distributed statement: SELECT NULL::unknown FROM ONLY articles_102053 WHERE (word_count > 10000)
  count 
 -------
     23

--- a/test/sql/05-create_shards.sql
+++ b/test/sql/05-create_shards.sql
@@ -101,7 +101,7 @@ SELECT storage, min_value, max_value FROM pgs_distribution_metadata.shard
 
 -- all shards should have the same size (16 divides evenly into the hash space)
 SELECT count(*) AS shard_count,
-	max_value::integer-min_value::integer AS shard_size
+	max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
 	WHERE relation_id='table_to_distribute'::regclass
 	GROUP BY shard_size;
@@ -165,7 +165,7 @@ SELECT master_create_worker_shards('weird_shard_count', 7, 1);
 \set VERBOSITY default
 
 -- pg_shard ensures all shards are roughly the same size
-SELECT max_value::integer-min_value::integer AS shard_size
+SELECT max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
 	WHERE relation_id='weird_shard_count'::regclass
 	ORDER BY min_value::integer ASC;

--- a/test/sql/05-create_shards.sql
+++ b/test/sql/05-create_shards.sql
@@ -167,7 +167,7 @@ SELECT master_create_worker_shards('weird_shard_count', 7, 1);
 -- pg_shard ensures all shards are roughly the same size
 SELECT max_value::integer - min_value::integer AS shard_size
 	FROM pgs_distribution_metadata.shard
-	WHERE relation_id='weird_shard_count'::regclass
+	WHERE relation_id = 'weird_shard_count'::regclass
 	ORDER BY min_value::integer ASC;
 
 -- cleanup foreign table, related shards and shard placements


### PR DESCRIPTION
There are `2^32` distinct "hash tokens" in our hash space, but we were using `INT32_MAX (2^32 - 1)` in the code instead. Because of this, shard counts which one might expect to divide evenly into the space (such as 16, 32, or 256) had fewer tokens than they should have. The remainder of the tokens were stuffed into the last shard, causing uneven load.

This fixes that by defining a 64-bit constant equal to `2^32` and then using that to calculate the distance between shards in the hash space.

Unlike #145, in "weird" shard counts, the first `n-1` shards will have one size and the final shard will have _all_ leftover tokens. This means the final shard could contain up to `n-1` more hash tokens than the other shards, which might have load implications. In #145, all shards are within one token of each other.

Look at the tests in each review to get an idea of the two approaches.