### PR TITLE
Makefile is updated to fix regression test failures on Redhat / Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 
 # test configuration
-TESTS = $(wildcard test/sql/*.sql)
+TESTS = $(sort $(wildcard test/sql/*.sql))
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-language=plpgsql
 REGRESS_OPTS += --launcher=./test/launcher.sh # use custom launcher for tests


### PR DESCRIPTION
On redhat/fedora, the regression tests fail due to the order of their execution. We haven't tried to figure out exactly why this happens, but on Redhat / Fedora, tests are executed out-of-order as follows:
```bash
/usr/local/pgsql/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --psqldir='/usr/local/pgsql/bin'    --inputdir=test --load-language=plpgsql --launcher=./test/launcher.sh  --dbname=contrib_regression 02-distribution_metadata 04-generate_ddl_commands 13-data_types 05-create_shards 11-citus_metadata_sync 03-extend_ddl_commands 10-utilities 09-queries 12-create_insert_proxy 07-repair_shards 01-connection 06-prune_shard_list 00-init 08-modifications
(using postmaster on Unix socket, default port)
============== dropping database "contrib_regression" ==============
NOTICE:  database "contrib_regression" does not exist, skipping
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== installing plpgsql                     ==============
CREATE LANGUAGE
============== running regression test queries        ==============
test 02-distribution_metadata ... FAILED
test 04-generate_ddl_commands ... FAILED
test 13-data_types            ... FAILED
test 05-create_shards         ... FAILED
test 11-citus_metadata_sync   ... FAILED
test 03-extend_ddl_commands   ... FAILED
test 10-utilities             ... FAILED
test 09-queries               ... FAILED
test 12-create_insert_proxy   ... FAILED
test 07-repair_shards         ... FAILED
test 01-connection            ... ok
test 06-prune_shard_list      ... FAILED
test 00-init                  ... ok
test 08-modifications         ... ok

========================
 11 of 14 tests failed. 
======================== 
```

In practice, we'd expect that tests are executed in the order, ie: 01, 02, ..., n. This change forces the tests being executed in the order on all operating systems.

Tested on Redhat 7.1 & Fedora 22.

