### PR TITLE
Update REAME

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -153,9 +153,9 @@ split -nl/64 input.csv chunks/
 ls chunks | xargs -t -n1 -P64 -I% copy_to_distributed_table -C % users
 ```
 
-Note that the above example loads the contents of `input.csv` using 64 processes. This number may need tuning depending on hardware and cluster size.
+Note that the above example loads the contents of `input.csv` using 64 processes. The optimal value will vary depending on factors such as cluster size and hardware.
 
-This advice applies similarly to application design: if you have workers loading data into a `pg_shard` cluster, experiment to determine the number of workers that maximize cluster utilization.
+This advice applies similarly to application design: if you have workers loading data into a `pg_shard` cluster, experiment to determine the number of workers that maximizes cluster utilization.
 
 ### Repairing Shards
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -143,12 +143,16 @@ Call the script with the `-h` for more usage information.
 
 ### Increasing INSERT throughput
 
-To maximize INSERT throughput, you should run statements in parallel. This helps utilizing multiple CPU cores. For instance, if you are loading data from two files you could run them in parallel such as the following:
+To maximize INSERT throughput, you should run statements in parallel. This helps utilizing multiple CPU cores. For instance, if you want to load the contents of the `input.csv`, first split the file and then run `copy_to_distributed_table` in parallel as shown below:
 
 ```
-copy_to_distributed_table -CH -d '|' -n NULL input_1.csv users &
-copy_to_distributed_table -CH -d '|' -n NULL input_2.csv users &
+mkdir chunks
+split -n l/64 input.csv chunks/
+find chunks/ -type f | xargs -n 1 -P 64 sh -c 'echo $0 `copy_to_distributed_table -C $0 users`'
 ```
+
+Note that the above commands load the contents of the `input.csv` with 64 concurrent connections. You can optimize that number with respect to your hardware. 
+
 
 Similarly, if you run statements on the PostgreSQL server via psql, you should open multiple connections and run the INSERT statements concurrently.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -141,6 +141,17 @@ copy_to_distributed_table -CH -d '|' -n NULL input.csv users
 
 Call the script with the `-h` for more usage information.
 
+### Increasing INSERT throughput
+
+To maximize INSERT throughput, you should run statements in parallel. This helps utilizing multiple CPU cores. For instance, if you are loading data from two files you could run them in parallel such as the following:
+
+```
+copy_to_distributed_table -CH -d '|' -n NULL input_1.csv users &
+copy_to_distributed_table -CH -d '|' -n NULL input_2.csv users &
+```
+
+Similarly, if you run statements on the PostgreSQL server via psql, you should open multiple connections and run the INSERT statements concurrently.
+
 ### Repairing Shards
 
 If for whatever reason a shard placement fails to be updated during a modification command, it will be marked as inactive. The `master_copy_shard_placement` function can be called to repair an inactive shard placement using data from a healthy placement. In order for this function to operate, `pg_shard` must be installed on _all_ worker nodes and not just the master node. The shard will be protected from any concurrent modifications during the repair.


### PR DESCRIPTION
This PR updates the README about increaing the INSERT throughput on pg_shard cluster.
In the last pg_shard sync meeting, we decided that mentioning the concurrent INSERTs may help users to get better performance. 

@jasonmp85 Feel free to change the wording&structure in the PR, my aim is to kick off this change.