### PR TITLE
Cache SPI plans to restore performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### pg_shard v1.2.3 (Unreleased) ###
+### pg_shard v1.2.3 (October 28, 2015) ###
 
 * Addresses a performance regression by caching metadata plans
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### pg_shard v1.2.3 (Unreleased) ###
+
+* Addresses a performance regression by caching metadata plans
+
 ### pg_shard v1.2.2 (August 28, 2015) ###
 
 * Changes default planner when running within CitusDB

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "pg_shard",
     "abstract": "Easy sharding for PostgreSQL",
     "description": "Shards and replicates PostgreSQL tables for horizontal scale and high availability. Seamlessly distributes SQL statements, without requiring any application changes.",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "maintainer": "\"Jason Petersen\" <jason@citusdata.com>",
     "license": "lgpl_3_0",
     "prereqs": {
@@ -17,7 +17,7 @@
             "abstract": "Easy sharding for PostgreSQL",
             "file": "sql/pg_shard--1.2.sql",
             "docfile": "README.md",
-            "version": "1.2.2"
+            "version": "1.2.3"
         }
     },
     "release_status": "stable",


### PR DESCRIPTION
Version v1.2 introduced the use of SPI in the metadata system to better abstract differences between pg_shard and CitusDB representations of distribution metadata. We didn't initially use cached SPI plans because cursory tests showed limited wins given the added complexity.

Well, additional tests uncovered _severe_ performance regressions when many writers are involved. This change caches each metadata function's SPI plan in a function-local static variable on first execution, using the cached plans on subsequent executions. After this change, we can restore performance to near v1.1 levels (SPI does inevitably add _some_ overhead, no matter what).