### PR TITLE
Restore 9.5 compatibility

### DIFF
--- a/src/generate_ddl_commands.c
+++ b/src/generate_ddl_commands.c
@@ -135,7 +135,11 @@ TableDDLCommandList(Oid relationId)
 			Oid constraintId = get_index_constraint(indexId);
 			Assert(constraintId != InvalidOid);
 
+#if (PG_VERSION_NUM >= 90300 && PG_VERSION_NUM < 90500)
 			statementDef = pg_get_constraintdef_string(constraintId);
+#else
+			statementDef = pg_get_constraintdef_command(constraintId);
+#endif
 		}
 		else
 		{

--- a/test/expected/04-generate_ddl_commands_1.out
+++ b/test/expected/04-generate_ddl_commands_1.out
@@ -1,0 +1,158 @@
+-- ===================================================================
+-- create test functions
+-- ===================================================================
+CREATE FUNCTION table_ddl_command_array(regclass)
+	RETURNS text[]
+	AS 'pg_shard'
+	LANGUAGE C STRICT;
+CREATE FUNCTION alter_server_host_and_port_command(server_name cstring,
+												   host cstring,
+												   port cstring)
+	RETURNS text
+	AS 'pg_shard'
+	LANGUAGE C STRICT;
+-- ===================================================================
+-- test ddl command generation functionality
+-- ===================================================================
+-- first make sure a simple table works
+CREATE TABLE simple_table (
+	first_name text,
+	last_name text,
+	id bigint
+);
+SELECT table_ddl_command_array('simple_table');
+                              table_ddl_command_array                              
+-----------------------------------------------------------------------------------
+ {"CREATE TABLE public.simple_table (first_name text, last_name text, id bigint)"}
+(1 row)
+
+-- ensure not-null constraints are propagated
+CREATE TABLE not_null_table (
+	city text,
+	id bigint not null
+);
+SELECT table_ddl_command_array('not_null_table');
+                        table_ddl_command_array                         
+------------------------------------------------------------------------
+ {"CREATE TABLE public.not_null_table (city text, id bigint NOT NULL)"}
+(1 row)
+
+-- even more complex constraints should be preserved...
+CREATE TABLE column_constraint_table (
+	first_name text,
+	last_name text,
+	age int CONSTRAINT non_negative_age CHECK (age >= 0)
+);
+SELECT table_ddl_command_array('column_constraint_table');
+                                                           table_ddl_command_array                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.column_constraint_table (first_name text, last_name text, age integer, CONSTRAINT non_negative_age CHECK (age >= 0))"}
+(1 row)
+
+-- including table constraints
+CREATE TABLE table_constraint_table (
+	bid_item_id bigint,
+	min_bid decimal not null,
+	max_bid decimal not null,
+	CONSTRAINT bids_ordered CHECK (min_bid > max_bid)
+);
+SELECT table_ddl_command_array('table_constraint_table');
+                                                                          table_ddl_command_array                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.table_constraint_table (bid_item_id bigint, min_bid numeric NOT NULL, max_bid numeric NOT NULL, CONSTRAINT bids_ordered CHECK (min_bid > max_bid))"}
+(1 row)
+
+-- default values are supported
+CREATE TABLE default_value_table (
+	name text,
+	price decimal default 0.00
+);
+SELECT table_ddl_command_array('default_value_table');
+                               table_ddl_command_array                               
+-------------------------------------------------------------------------------------
+ {"CREATE TABLE public.default_value_table (name text, price numeric DEFAULT 0.00)"}
+(1 row)
+
+-- of course primary keys work...
+CREATE TABLE pkey_table (
+	first_name text,
+	last_name text,
+	id bigint PRIMARY KEY
+);
+SELECT table_ddl_command_array('pkey_table');
+                                                                         table_ddl_command_array                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.pkey_table (first_name text, last_name text, id bigint NOT NULL)","ALTER TABLE public.pkey_table ADD CONSTRAINT pkey_table_pkey PRIMARY KEY (id)"}
+(1 row)
+
+-- as do unique indexes...
+CREATE TABLE unique_table (
+	user_id bigint not null,
+	username text UNIQUE not null
+);
+SELECT table_ddl_command_array('unique_table');
+                                                                               table_ddl_command_array                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.unique_table (user_id bigint NOT NULL, username text NOT NULL)","ALTER TABLE public.unique_table ADD CONSTRAINT unique_table_username_key UNIQUE (username)"}
+(1 row)
+
+-- and indexes used for clustering
+CREATE TABLE clustered_table (
+	data json not null,
+	received_at timestamp not null
+);
+CREATE INDEX clustered_time_idx ON clustered_table (received_at);
+CLUSTER clustered_table USING clustered_time_idx;
+SELECT table_ddl_command_array('clustered_table');
+                                                                                                                     table_ddl_command_array                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.clustered_table (data json NOT NULL, received_at timestamp without time zone NOT NULL)","CREATE INDEX clustered_time_idx ON clustered_table USING btree (received_at)","ALTER TABLE public.clustered_table CLUSTER ON clustered_time_idx"}
+(1 row)
+
+-- fiddly things like storage type and statistics also work
+CREATE TABLE fiddly_table (
+	hostname char(255) not null,
+	os char(255) not null,
+	ip_addr inet not null,
+	traceroute text not null
+);
+ALTER TABLE fiddly_table
+	ALTER hostname SET STORAGE PLAIN,
+	ALTER os SET STORAGE MAIN,
+	ALTER ip_addr SET STORAGE EXTENDED,
+	ALTER traceroute SET STORAGE EXTERNAL,
+	ALTER ip_addr SET STATISTICS 500;
+SELECT table_ddl_command_array('fiddly_table');
+                                                                                                                                                                                         table_ddl_command_array                                                                                                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE TABLE public.fiddly_table (hostname character(255) NOT NULL, os character(255) NOT NULL, ip_addr inet NOT NULL, traceroute text NOT NULL)","ALTER TABLE ONLY public.fiddly_table ALTER COLUMN hostname SET STORAGE PLAIN, ALTER COLUMN os SET STORAGE MAIN, ALTER COLUMN ip_addr SET STORAGE EXTENDED, ALTER COLUMN ip_addr SET STATISTICS 500, ALTER COLUMN traceroute SET STORAGE EXTERNAL"}
+(1 row)
+
+-- test foreign tables using fake FDW
+CREATE FOREIGN TABLE foreign_table (
+	id bigint not null,
+	full_name text not null default ''
+) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true');
+SELECT table_ddl_command_array('foreign_table');
+                                                                              table_ddl_command_array                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"CREATE FOREIGN TABLE public.foreign_table (id bigint NOT NULL, full_name text DEFAULT ''::text NOT NULL) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true')"}
+(1 row)
+
+-- propagating views is not supported
+CREATE VIEW local_view AS SELECT * FROM simple_table;
+SELECT table_ddl_command_array('local_view');
+ERROR:  public.local_view is not a regular or foreign table
+-- independently test option-generation code
+SELECT alter_server_host_and_port_command('fake_fdw_server', 'localhost', '5432');
+                  alter_server_host_and_port_command                  
+----------------------------------------------------------------------
+ ALTER SERVER fake_fdw_server OPTIONS (host 'localhost', port '5432')
+(1 row)
+
+-- clean up
+DROP VIEW IF EXISTS local_view;
+DROP FOREIGN TABLE IF EXISTS foreign_table;
+DROP TABLE IF EXISTS simple_table, not_null_table, column_constraint_table,
+					 table_constraint_table, default_value_table, pkey_table,
+					 unique_table, clustered_table, fiddly_table;

--- a/test/src/fake_fdw.c
+++ b/test/src/fake_fdw.c
@@ -35,9 +35,16 @@ static void FakeGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel,
 								  Oid foreigntableid);
 static void FakeGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel,
 								Oid foreigntableid);
+#if (PG_VERSION_NUM >= 90300 && PG_VERSION_NUM < 90500)
 static ForeignScan * FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel,
 										Oid foreigntableid, ForeignPath *best_path,
 										List *tlist, List *scan_clauses);
+#else
+static ForeignScan * FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel,
+										Oid foreigntableid, ForeignPath *best_path,
+										List *tlist, List *scan_clauses,
+										Plan *outer_plan);
+#endif
 static void FakeBeginForeignScan(ForeignScanState *node, int eflags);
 static TupleTableSlot * FakeIterateForeignScan(ForeignScanState *node);
 static void FakeReScanForeignScan(ForeignScanState *node);
@@ -89,18 +96,31 @@ FakeGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
 	Cost startup_cost = 0;
 	Cost total_cost = startup_cost + baserel->rows;
 
+#if (PG_VERSION_NUM >= 90300 && PG_VERSION_NUM < 90500)
 	add_path(baserel, (Path *) create_foreignscan_path(root, baserel, baserel->rows,
 													   startup_cost, total_cost, NIL,
 													   NULL, NIL));
+#else
+	add_path(baserel, (Path *) create_foreignscan_path(root, baserel, baserel->rows,
+													   startup_cost, total_cost, NIL,
+													   NULL, NULL, NIL));
+#endif
 }
 
 
 /*
  * FakeGetForeignPlan builds a fake foreign plan.
  */
+#if (PG_VERSION_NUM >= 90300 && PG_VERSION_NUM < 90500)
 static ForeignScan *
 FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
 				   ForeignPath *best_path, List *tlist, List *scan_clauses)
+#else
+static ForeignScan *
+FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
+				   ForeignPath *best_path, List *tlist, List *scan_clauses,
+				   Plan *outer_plan)
+#endif
 {
 	Index scan_relid = baserel->relid;
 	scan_clauses = extract_actual_clauses(scan_clauses, false);
@@ -109,7 +129,8 @@ FakeGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
 #if (PG_VERSION_NUM >= 90300 && PG_VERSION_NUM < 90500)
 	return make_foreignscan(tlist, scan_clauses, scan_relid, NIL, NIL);
 #else
-	return make_foreignscan(tlist, scan_clauses, scan_relid, NIL, NIL, NIL);
+	return make_foreignscan(tlist, scan_clauses, scan_relid, NIL, NIL, NIL, NIL,
+	                        outer_plan);
 #endif
 }
 


### PR DESCRIPTION
Just need a couple of preprocessor conditionals. But how to clean up?

Probably about to merge this myself to get us to a clean build state with the final 9.5; however, we'll want to discuss how to encapsulate this version-checking to keep our code a little cleaner.
